### PR TITLE
Bugfix/27

### DIFF
--- a/ble/src/main/java/no/nordicsemi/android/ble/BleManager.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/BleManager.java
@@ -2249,13 +2249,14 @@ public abstract class BleManager<E extends BleManagerCallbacks> implements ILogg
 
 					// Reset flag, so the next Connect could be enqueued.
 					mOperationInProgress = false;
-					// Try to reconnect if the initial connection was lost because of a link loss
-					// or timeout, and shouldAutoConnect() returned true during connection attempt.
+					// Try to reconnect if the initial connection was lost because of a link loss,
+					// and shouldAutoConnect() returned true during connection attempt.
 					// This time it will set the autoConnect flag to true (gatt.connect() forces
 					// autoConnect true).
-					if (mInitialConnection) {
+					if (wasConnected && mInitialConnection) {
 						internalConnect(gatt.getDevice(), 0 /* unused */);
 					} else {
+						mInitialConnection = false;
 						nextRequest(false);
 					}
 

--- a/ble/src/main/java/no/nordicsemi/android/ble/BleManager.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/BleManager.java
@@ -947,8 +947,7 @@ public abstract class BleManager<E extends BleManagerCallbacks> implements ILogg
 	 * @return The callback.
 	 */
 	@NonNull
-	protected final ValueChangedCallback setNotificationCallback(
-			@Nullable final BluetoothGattCharacteristic characteristic) {
+	protected final ValueChangedCallback setNotificationCallback(@Nullable final BluetoothGattCharacteristic characteristic) {
 		ValueChangedCallback callback = mNotificationCallbacks.get(characteristic);
 		if (callback == null) {
 			callback = new ValueChangedCallback();
@@ -973,8 +972,7 @@ public abstract class BleManager<E extends BleManagerCallbacks> implements ILogg
 	 * @return The callback.
 	 */
 	@NonNull
-	protected final ValueChangedCallback setIndicationCallback(
-			@Nullable final BluetoothGattCharacteristic characteristic) {
+	protected final ValueChangedCallback setIndicationCallback(@Nullable final BluetoothGattCharacteristic characteristic) {
 		return setNotificationCallback(characteristic);
 	}
 
@@ -1211,8 +1209,8 @@ public abstract class BleManager<E extends BleManagerCallbacks> implements ILogg
 	 * @return The request.
 	 */
 	@NonNull
-	protected final WriteRequest writeCharacteristic(
-			@Nullable final BluetoothGattCharacteristic characteristic, @Nullable final Data data) {
+	protected final WriteRequest writeCharacteristic(@Nullable final BluetoothGattCharacteristic characteristic,
+													 @Nullable final Data data) {
 		return Request.newWriteRequest(characteristic, data != null ? data.getValue() : null)
 				.setManager(this);
 	}
@@ -1234,9 +1232,8 @@ public abstract class BleManager<E extends BleManagerCallbacks> implements ILogg
 	 * @return The request.
 	 */
 	@NonNull
-	protected final WriteRequest writeCharacteristic(
-			@Nullable final BluetoothGattCharacteristic characteristic,
-			@Nullable final byte[] data) {
+	protected final WriteRequest writeCharacteristic(@Nullable final BluetoothGattCharacteristic characteristic,
+													 @Nullable final byte[] data) {
 		return Request.newWriteRequest(characteristic, data).setManager(this);
 	}
 
@@ -1260,9 +1257,8 @@ public abstract class BleManager<E extends BleManagerCallbacks> implements ILogg
 	 * @return The request.
 	 */
 	@NonNull
-	protected final WriteRequest writeCharacteristic(
-			@Nullable final BluetoothGattCharacteristic characteristic,
-			@Nullable final byte[] data, final int offset, final int length) {
+	protected final WriteRequest writeCharacteristic(@Nullable final BluetoothGattCharacteristic characteristic,
+													 @Nullable final byte[] data, final int offset, final int length) {
 		return Request.newWriteRequest(characteristic, data, offset, length).setManager(this);
 	}
 
@@ -1637,14 +1633,12 @@ public abstract class BleManager<E extends BleManagerCallbacks> implements ILogg
 	 *                   {@link PhyRequest#PHY_OPTION_S2} or {@link PhyRequest#PHY_OPTION_S8}.
 	 * @return The request.
 	 */
-	protected final PhyRequest setPreferredPhy(final int txPhy, final int rxPhy,
-											   final int phyOptions) {
+	protected final PhyRequest setPreferredPhy(final int txPhy, final int rxPhy, final int phyOptions) {
 		return Request.newSetPreferredPhyRequest(txPhy, rxPhy, phyOptions).setManager(this);
 	}
 
 	@RequiresApi(api = Build.VERSION_CODES.O)
-	private boolean internalSetPreferredPhy(final int txPhy, final int rxPhy,
-											final int phyOptions) {
+	private boolean internalSetPreferredPhy(final int txPhy, final int rxPhy, final int phyOptions) {
 		final BluetoothGatt gatt = mBluetoothGatt;
 		if (gatt == null || !mConnected)
 			return false;
@@ -2105,8 +2099,7 @@ public abstract class BleManager<E extends BleManagerCallbacks> implements ILogg
 		}
 
 		@Override
-		final void onConnectionStateChangeSafe(@NonNull final BluetoothGatt gatt, final int status,
-											   final int newState) {
+		final void onConnectionStateChangeSafe(@NonNull final BluetoothGatt gatt, final int status, final int newState) {
 			log(Level.DEBUG, "[Callback] Connection state changed with status: " +
 					status + " and new state: " + newState + " (" + stateToString(newState) + ")");
 
@@ -2232,8 +2225,7 @@ public abstract class BleManager<E extends BleManagerCallbacks> implements ILogg
 		}
 
 		@Override
-		final void onServicesDiscoveredSafe(@NonNull final BluetoothGatt gatt,
-											final int status) {
+		final void onServicesDiscoveredSafe(@NonNull final BluetoothGatt gatt, final int status) {
 			mServiceDiscoveryRequested = false;
 			if (status == BluetoothGatt.GATT_SUCCESS) {
 				log(Level.INFO, "Services discovered");
@@ -2316,8 +2308,7 @@ public abstract class BleManager<E extends BleManagerCallbacks> implements ILogg
 		@Override
 		final void onCharacteristicReadSafe(@NonNull final BluetoothGatt gatt,
 											@NonNull final BluetoothGattCharacteristic characteristic,
-											@Nullable final byte[] data,
-											final int status) {
+											@Nullable final byte[] data, final int status) {
 			if (status == BluetoothGatt.GATT_SUCCESS) {
 				log(Level.INFO, "Read Response received from " + characteristic.getUuid() +
 						", value: " + ParserUtils.parse(data));
@@ -2356,8 +2347,7 @@ public abstract class BleManager<E extends BleManagerCallbacks> implements ILogg
 		@Override
 		final void onCharacteristicWriteSafe(@NonNull final BluetoothGatt gatt,
 											 @NonNull final BluetoothGattCharacteristic characteristic,
-											 @Nullable final byte[] data,
-											 final int status) {
+											 @Nullable final byte[] data, final int status) {
 			if (status == BluetoothGatt.GATT_SUCCESS) {
 				log(Level.INFO, "Data written to " + characteristic.getUuid() +
 						", value: " + ParserUtils.parse(data));
@@ -2441,8 +2431,7 @@ public abstract class BleManager<E extends BleManagerCallbacks> implements ILogg
 		@Override
 		final void onDescriptorWriteSafe(@NonNull final BluetoothGatt gatt,
 										 @NonNull final BluetoothGattDescriptor descriptor,
-										 @Nullable final byte[] data,
-										 final int status) {
+										 @Nullable final byte[] data, final int status) {
 			if (status == BluetoothGatt.GATT_SUCCESS) {
 				log(Level.INFO, "Data written to descr. " + descriptor.getUuid() +
 						", value: " + ParserUtils.parse(data));
@@ -2682,8 +2671,8 @@ public abstract class BleManager<E extends BleManagerCallbacks> implements ILogg
 		}
 
 		@Override
-		final void onReadRemoteRssiSafe(@NonNull final BluetoothGatt gatt, final int rssi,
-										final int status) {
+		final void onReadRemoteRssiSafe(@NonNull final BluetoothGatt gatt,
+										final int rssi, final int status) {
 			if (status == BluetoothGatt.GATT_SUCCESS) {
 				log(Level.INFO, "Remote RSSI received: " + rssi + " dBm");
 				if (mRequest instanceof ReadRssiRequest) {
@@ -2707,7 +2696,7 @@ public abstract class BleManager<E extends BleManagerCallbacks> implements ILogg
 		 *
 		 * @param request the request to be added.
 		 */
-		private void enqueueFirst(final Request request) {
+		private void enqueueFirst(@NonNull final Request request) {
 			final Deque<Request> queue = mInitInProgress ? mInitQueue : mTaskQueue;
 			queue.addFirst(request);
 			request.enqueued = true;
@@ -2719,7 +2708,7 @@ public abstract class BleManager<E extends BleManagerCallbacks> implements ILogg
 		 *
 		 * @param request the request to be added.
 		 */
-		private void enqueue(final Request request) {
+		private void enqueue(@NonNull final Request request) {
 			final Deque<Request> queue = mInitInProgress ? mInitQueue : mTaskQueue;
 			queue.add(request);
 			request.enqueued = true;
@@ -3001,7 +2990,7 @@ public abstract class BleManager<E extends BleManagerCallbacks> implements ILogg
 		 * @param descriptor the descriptor to be checked
 		 * @return true if the descriptor belongs to the Service Changed characteristic
 		 */
-		private boolean isServiceChangedCCCD(final BluetoothGattDescriptor descriptor) {
+		private boolean isServiceChangedCCCD(@Nullable final BluetoothGattDescriptor descriptor) {
 			return descriptor != null &&
 					SERVICE_CHANGED_CHARACTERISTIC.equals(descriptor.getCharacteristic().getUuid());
 		}
@@ -3012,8 +3001,7 @@ public abstract class BleManager<E extends BleManagerCallbacks> implements ILogg
 		 * @param characteristic the characteristic to be checked
 		 * @return true if it is the Service Changed characteristic
 		 */
-		private boolean isServiceChangedCharacteristic(
-				final BluetoothGattCharacteristic characteristic) {
+		private boolean isServiceChangedCharacteristic(@Nullable final BluetoothGattCharacteristic characteristic) {
 			return characteristic != null &&
 					SERVICE_CHANGED_CHARACTERISTIC.equals(characteristic.getUuid());
 		}
@@ -3025,8 +3013,7 @@ public abstract class BleManager<E extends BleManagerCallbacks> implements ILogg
 		 * @return true if the characteristic is the Battery Level characteristic.
 		 */
 		@Deprecated
-		private boolean isBatteryLevelCharacteristic(
-				final BluetoothGattCharacteristic characteristic) {
+		private boolean isBatteryLevelCharacteristic(@Nullable final BluetoothGattCharacteristic characteristic) {
 			return characteristic != null &&
 					BATTERY_LEVEL_CHARACTERISTIC.equals(characteristic.getUuid());
 		}

--- a/ble/src/main/java/no/nordicsemi/android/ble/ConnectRequest.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/ConnectRequest.java
@@ -27,6 +27,7 @@ import android.support.annotation.NonNull;
 
 import no.nordicsemi.android.ble.callback.BeforeCallback;
 import no.nordicsemi.android.ble.callback.FailCallback;
+import no.nordicsemi.android.ble.callback.InvalidRequestCallback;
 import no.nordicsemi.android.ble.callback.SuccessCallback;
 
 @SuppressWarnings({"WeakerAccess", "unused"})
@@ -90,6 +91,13 @@ public class ConnectRequest extends Request {
 	@Override
 	public ConnectRequest fail(@NonNull final FailCallback callback) {
 		super.fail(callback);
+		return this;
+	}
+
+	@NonNull
+	@Override
+	public ConnectRequest invalid(@NonNull final InvalidRequestCallback callback) {
+		super.invalid(callback);
 		return this;
 	}
 

--- a/ble/src/main/java/no/nordicsemi/android/ble/ConnectionPriorityRequest.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/ConnectionPriorityRequest.java
@@ -30,9 +30,11 @@ import android.support.annotation.RequiresApi;
 import no.nordicsemi.android.ble.callback.BeforeCallback;
 import no.nordicsemi.android.ble.callback.ConnectionPriorityCallback;
 import no.nordicsemi.android.ble.callback.FailCallback;
+import no.nordicsemi.android.ble.callback.InvalidRequestCallback;
 import no.nordicsemi.android.ble.callback.SuccessCallback;
 import no.nordicsemi.android.ble.exception.BluetoothDisabledException;
 import no.nordicsemi.android.ble.exception.DeviceDisconnectedException;
+import no.nordicsemi.android.ble.exception.InvalidRequestException;
 import no.nordicsemi.android.ble.exception.RequestFailedException;
 
 @SuppressWarnings({"unused", "WeakerAccess"})
@@ -95,6 +97,13 @@ public final class ConnectionPriorityRequest extends ValueRequest<ConnectionPrio
 		return this;
 	}
 
+	@NonNull
+	@Override
+	public ConnectionPriorityRequest invalid(@NonNull final InvalidRequestCallback callback) {
+		super.invalid(callback);
+		return this;
+	}
+
 	@Override
 	@NonNull
 	public ConnectionPriorityRequest before(@NonNull final BeforeCallback callback) {
@@ -115,7 +124,8 @@ public final class ConnectionPriorityRequest extends ValueRequest<ConnectionPrio
 	@NonNull
 	@Override
 	public <E extends ConnectionPriorityCallback> E await(final Class<E> responseClass)
-			throws RequestFailedException, DeviceDisconnectedException, BluetoothDisabledException {
+			throws RequestFailedException, DeviceDisconnectedException, BluetoothDisabledException,
+			InvalidRequestException {
 		// The BluetoothGattCallback#onConnectionUpdated callback was introduced in Android Oreo.
 		return super.await(responseClass);
 	}
@@ -126,7 +136,7 @@ public final class ConnectionPriorityRequest extends ValueRequest<ConnectionPrio
 	public <E extends ConnectionPriorityCallback> E await(@NonNull final Class<E> responseClass,
 														  final int timeout)
 			throws RequestFailedException, InterruptedException, DeviceDisconnectedException,
-			BluetoothDisabledException {
+			BluetoothDisabledException, InvalidRequestException {
 		// The BluetoothGattCallback#onConnectionUpdated callback was introduced in Android Oreo.
 		return super.await(responseClass, timeout);
 	}

--- a/ble/src/main/java/no/nordicsemi/android/ble/DisconnectRequest.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/DisconnectRequest.java
@@ -26,6 +26,7 @@ import android.support.annotation.NonNull;
 
 import no.nordicsemi.android.ble.callback.BeforeCallback;
 import no.nordicsemi.android.ble.callback.FailCallback;
+import no.nordicsemi.android.ble.callback.InvalidRequestCallback;
 import no.nordicsemi.android.ble.callback.SuccessCallback;
 
 @SuppressWarnings("WeakerAccess")
@@ -53,6 +54,13 @@ public class DisconnectRequest extends Request {
 	@Override
 	public DisconnectRequest fail(@NonNull final FailCallback callback) {
 		super.fail(callback);
+		return this;
+	}
+
+	@NonNull
+	@Override
+	public DisconnectRequest invalid(@NonNull final InvalidRequestCallback callback) {
+		super.invalid(callback);
 		return this;
 	}
 

--- a/ble/src/main/java/no/nordicsemi/android/ble/MainThreadBluetoothGattCallback.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/MainThreadBluetoothGattCallback.java
@@ -42,7 +42,7 @@ import android.support.annotation.RequiresApi;
 abstract class MainThreadBluetoothGattCallback extends BluetoothGattCallback {
 	private Handler mHandler;
 
-	void setHandler(final Handler handler) {
+	void setHandler(@NonNull final Handler handler) {
 		mHandler = handler;
 	}
 

--- a/ble/src/main/java/no/nordicsemi/android/ble/MtuRequest.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/MtuRequest.java
@@ -27,6 +27,7 @@ import android.support.annotation.NonNull;
 
 import no.nordicsemi.android.ble.callback.BeforeCallback;
 import no.nordicsemi.android.ble.callback.FailCallback;
+import no.nordicsemi.android.ble.callback.InvalidRequestCallback;
 import no.nordicsemi.android.ble.callback.MtuCallback;
 import no.nordicsemi.android.ble.callback.SuccessCallback;
 
@@ -60,6 +61,13 @@ public final class MtuRequest extends ValueRequest<MtuCallback> {
 	@NonNull
 	public MtuRequest fail(@NonNull final FailCallback callback) {
 		this.failCallback = callback;
+		return this;
+	}
+
+	@NonNull
+	@Override
+	public MtuRequest invalid(@NonNull final InvalidRequestCallback callback) {
+		super.invalid(callback);
 		return this;
 	}
 

--- a/ble/src/main/java/no/nordicsemi/android/ble/PhyRequest.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/PhyRequest.java
@@ -27,6 +27,7 @@ import android.support.annotation.NonNull;
 
 import no.nordicsemi.android.ble.callback.BeforeCallback;
 import no.nordicsemi.android.ble.callback.FailCallback;
+import no.nordicsemi.android.ble.callback.InvalidRequestCallback;
 import no.nordicsemi.android.ble.callback.PhyCallback;
 import no.nordicsemi.android.ble.callback.SuccessCallback;
 
@@ -107,6 +108,13 @@ public final class PhyRequest extends ValueRequest<PhyCallback> {
 	@NonNull
 	public PhyRequest fail(@NonNull final FailCallback callback) {
 		this.failCallback = callback;
+		return this;
+	}
+
+	@NonNull
+	@Override
+	public PhyRequest invalid(@NonNull final InvalidRequestCallback callback) {
+		super.invalid(callback);
 		return this;
 	}
 

--- a/ble/src/main/java/no/nordicsemi/android/ble/ReadRequest.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/ReadRequest.java
@@ -32,6 +32,7 @@ import android.support.annotation.Nullable;
 import no.nordicsemi.android.ble.callback.BeforeCallback;
 import no.nordicsemi.android.ble.callback.DataReceivedCallback;
 import no.nordicsemi.android.ble.callback.FailCallback;
+import no.nordicsemi.android.ble.callback.InvalidRequestCallback;
 import no.nordicsemi.android.ble.callback.ReadProgressCallback;
 import no.nordicsemi.android.ble.callback.SuccessCallback;
 import no.nordicsemi.android.ble.callback.profile.ProfileReadResponse;
@@ -41,9 +42,10 @@ import no.nordicsemi.android.ble.data.DataStream;
 import no.nordicsemi.android.ble.exception.BluetoothDisabledException;
 import no.nordicsemi.android.ble.exception.DeviceDisconnectedException;
 import no.nordicsemi.android.ble.exception.InvalidDataException;
+import no.nordicsemi.android.ble.exception.InvalidRequestException;
 import no.nordicsemi.android.ble.exception.RequestFailedException;
 
-@SuppressWarnings("unused")
+@SuppressWarnings({"unused", "WeakerAccess"})
 public final class ReadRequest extends ValueRequest<DataReceivedCallback> {
 	private ReadProgressCallback progressCallback;
 	private DataMerger dataMerger;
@@ -80,6 +82,13 @@ public final class ReadRequest extends ValueRequest<DataReceivedCallback> {
 	@NonNull
 	public ReadRequest fail(@NonNull final FailCallback callback) {
 		this.failCallback = callback;
+		return this;
+	}
+
+	@NonNull
+	@Override
+	public ReadRequest invalid(@NonNull final InvalidRequestCallback callback) {
+		super.invalid(callback);
 		return this;
 	}
 
@@ -145,11 +154,13 @@ public final class ReadRequest extends ValueRequest<DataReceivedCallback> {
      *                                     {@link ProfileReadResponse#onDataReceived(BluetoothDevice, Data)}
      *                                     failed to parse the data correctly and called
      *                                     {@link ProfileReadResponse#onInvalidDataReceived(BluetoothDevice, Data)}).
+	 * @throws InvalidRequestException     thrown when the request was called before the device was
+	 *                                     connected at least once (unknown device).
 	 */
 	@NonNull
 	public <E extends ProfileReadResponse> E awaitValid(@NonNull final Class<E> responseClass)
 			throws RequestFailedException, InvalidDataException, DeviceDisconnectedException,
-			BluetoothDisabledException {
+			BluetoothDisabledException, InvalidRequestException {
 		E response = await(responseClass);
 		if (!response.isValid()) {
 			throw new InvalidDataException(response);
@@ -176,11 +187,13 @@ public final class ReadRequest extends ValueRequest<DataReceivedCallback> {
      *                                     {@link ProfileReadResponse#onDataReceived(BluetoothDevice, Data)}
      *                                     failed to parse the data correctly and called
      *                                     {@link ProfileReadResponse#onInvalidDataReceived(BluetoothDevice, Data)}).
+	 * @throws InvalidRequestException     thrown when the request was called before the device was
+	 *                                     connected at least once (unknown device).
 	 */
 	@NonNull
 	public <E extends ProfileReadResponse> E awaitValid(@NonNull final E response)
 			throws RequestFailedException, InvalidDataException, DeviceDisconnectedException,
-			BluetoothDisabledException {
+			BluetoothDisabledException, InvalidRequestException {
 		await(response);
 		if (!response.isValid()) {
 			throw new InvalidDataException(response);
@@ -212,12 +225,14 @@ public final class ReadRequest extends ValueRequest<DataReceivedCallback> {
      *                                     {@link ProfileReadResponse#onDataReceived(BluetoothDevice, Data)}
      *                                     failed to parse the data correctly and called
      *                                     {@link ProfileReadResponse#onInvalidDataReceived(BluetoothDevice, Data)}).
+	 * @throws InvalidRequestException     thrown when the request was called before the device was
+	 *                                     connected at least once (unknown device).
 	 */
 	@NonNull
 	public <E extends ProfileReadResponse> E awaitValid(@NonNull final Class<E> responseClass,
 														final int timeout)
 			throws RequestFailedException, InterruptedException, InvalidDataException,
-			DeviceDisconnectedException, BluetoothDisabledException {
+			DeviceDisconnectedException, BluetoothDisabledException, InvalidRequestException {
 		E response = await(responseClass, timeout);
 		if (!response.isValid()) {
 			throw new InvalidDataException(response);
@@ -247,12 +262,14 @@ public final class ReadRequest extends ValueRequest<DataReceivedCallback> {
      *                                     {@link ProfileReadResponse#onDataReceived(BluetoothDevice, Data)}
      *                                     failed to parse the data correctly and called
      *                                     {@link ProfileReadResponse#onInvalidDataReceived(BluetoothDevice, Data)}).
+	 * @throws InvalidRequestException     thrown when the request was called before the device was
+	 *                                     connected at least once (unknown device).
 	 */
 	@NonNull
 	public <E extends ProfileReadResponse> E awaitValid(@NonNull final E response,
 														final int timeout)
 			throws RequestFailedException, InterruptedException, InvalidDataException,
-			DeviceDisconnectedException, BluetoothDisabledException {
+			DeviceDisconnectedException, BluetoothDisabledException, InvalidRequestException {
 		await(response, timeout);
 		if (!response.isValid()) {
 			throw new InvalidDataException(response);

--- a/ble/src/main/java/no/nordicsemi/android/ble/ReadRssiRequest.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/ReadRssiRequest.java
@@ -27,6 +27,7 @@ import android.support.annotation.NonNull;
 
 import no.nordicsemi.android.ble.callback.BeforeCallback;
 import no.nordicsemi.android.ble.callback.FailCallback;
+import no.nordicsemi.android.ble.callback.InvalidRequestCallback;
 import no.nordicsemi.android.ble.callback.RssiCallback;
 import no.nordicsemi.android.ble.callback.SuccessCallback;
 
@@ -54,6 +55,13 @@ public final class ReadRssiRequest extends ValueRequest<RssiCallback> {
 	@NonNull
 	public ReadRssiRequest fail(@NonNull final FailCallback callback) {
 		this.failCallback = callback;
+		return this;
+	}
+
+	@NonNull
+	@Override
+	public ReadRssiRequest invalid(@NonNull final InvalidRequestCallback callback) {
+		super.invalid(callback);
 		return this;
 	}
 

--- a/ble/src/main/java/no/nordicsemi/android/ble/Request.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/Request.java
@@ -839,7 +839,7 @@ public class Request {
 				timeoutHandler = null;
 				if (!finished) {
 					notifyFail(manager.getBluetoothDevice(), FailCallback.REASON_TIMEOUT);
-					manager.onRequestTimeout();
+					manager.onRequestTimeout(this);
 				}
 			};
 			manager.mHandler.postDelayed(timeoutHandler, timeout);

--- a/ble/src/main/java/no/nordicsemi/android/ble/WaitForValueChangedRequest.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/WaitForValueChangedRequest.java
@@ -31,6 +31,7 @@ import android.support.annotation.Nullable;
 import no.nordicsemi.android.ble.callback.BeforeCallback;
 import no.nordicsemi.android.ble.callback.DataReceivedCallback;
 import no.nordicsemi.android.ble.callback.FailCallback;
+import no.nordicsemi.android.ble.callback.InvalidRequestCallback;
 import no.nordicsemi.android.ble.callback.ReadProgressCallback;
 import no.nordicsemi.android.ble.callback.SuccessCallback;
 import no.nordicsemi.android.ble.callback.profile.ProfileReadResponse;
@@ -40,6 +41,7 @@ import no.nordicsemi.android.ble.data.DataStream;
 import no.nordicsemi.android.ble.exception.BluetoothDisabledException;
 import no.nordicsemi.android.ble.exception.DeviceDisconnectedException;
 import no.nordicsemi.android.ble.exception.InvalidDataException;
+import no.nordicsemi.android.ble.exception.InvalidRequestException;
 import no.nordicsemi.android.ble.exception.RequestFailedException;
 
 @SuppressWarnings({"unused", "WeakerAccess"})
@@ -76,6 +78,13 @@ public class WaitForValueChangedRequest extends ValueRequest<DataReceivedCallbac
 	@Override
 	public WaitForValueChangedRequest fail(@NonNull final FailCallback callback) {
 		super.fail(callback);
+		return this;
+	}
+
+	@NonNull
+	@Override
+	public WaitForValueChangedRequest invalid(@NonNull final InvalidRequestCallback callback) {
+		super.invalid(callback);
 		return this;
 	}
 
@@ -204,12 +213,14 @@ public class WaitForValueChangedRequest extends ValueRequest<DataReceivedCallbac
 	 *                                     {@link ProfileReadResponse#onDataReceived(BluetoothDevice, Data)}
 	 *                                     failed to parse the data correctly and called
 	 *                                     {@link ProfileReadResponse#onInvalidDataReceived(BluetoothDevice, Data)}).
+	 * @throws InvalidRequestException     thrown when the request was called before the device was
+	 *                                     connected at least once (unknown device).
 	 */
 	@SuppressWarnings("ConstantConditions")
 	@NonNull
 	public <E extends ProfileReadResponse> E awaitValid(@NonNull final Class<E> responseClass)
 			throws RequestFailedException, InvalidDataException, DeviceDisconnectedException,
-			BluetoothDisabledException {
+			BluetoothDisabledException, InvalidRequestException {
 		try {
 			return awaitValid(responseClass, 0);
 		} catch (final InterruptedException e) {
@@ -272,13 +283,15 @@ public class WaitForValueChangedRequest extends ValueRequest<DataReceivedCallbac
 	 *                                     {@link ProfileReadResponse#onDataReceived(BluetoothDevice, Data)}
 	 *                                     failed to parse the data correctly and called
 	 *                                     {@link ProfileReadResponse#onInvalidDataReceived(BluetoothDevice, Data)}).
+	 * @throws InvalidRequestException     thrown when the request was called before the device was
+	 *                                     connected at least once (unknown device).
 	 */
 	@SuppressWarnings("ConstantConditions")
 	@NonNull
 	public <E extends ProfileReadResponse> E awaitValid(@NonNull final Class<E> responseClass,
 														final int timeout)
 			throws InterruptedException, InvalidDataException, RequestFailedException,
-			DeviceDisconnectedException, BluetoothDisabledException {
+			DeviceDisconnectedException, BluetoothDisabledException, InvalidRequestException {
 		final E response = await(responseClass, timeout);
 		if (response != null && !response.isValid()) {
 			throw new InvalidDataException(response);

--- a/ble/src/main/java/no/nordicsemi/android/ble/WriteRequest.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/WriteRequest.java
@@ -31,6 +31,7 @@ import android.support.annotation.Nullable;
 import no.nordicsemi.android.ble.callback.BeforeCallback;
 import no.nordicsemi.android.ble.callback.DataSentCallback;
 import no.nordicsemi.android.ble.callback.FailCallback;
+import no.nordicsemi.android.ble.callback.InvalidRequestCallback;
 import no.nordicsemi.android.ble.callback.SuccessCallback;
 import no.nordicsemi.android.ble.callback.WriteProgressCallback;
 import no.nordicsemi.android.ble.data.Data;
@@ -95,28 +96,35 @@ public final class WriteRequest extends ValueRequest<DataSentCallback> {
 	@Override
 	@NonNull
 	public WriteRequest done(@NonNull final SuccessCallback callback) {
-		this.successCallback = callback;
+		super.done(callback);
 		return this;
 	}
 
 	@Override
 	@NonNull
 	public WriteRequest fail(@NonNull final FailCallback callback) {
-		this.failCallback = callback;
+		super.fail(callback);
+		return this;
+	}
+
+	@NonNull
+	@Override
+	public WriteRequest invalid(@NonNull final InvalidRequestCallback callback) {
+		super.invalid(callback);
 		return this;
 	}
 
 	@Override
 	@NonNull
 	public WriteRequest before(@NonNull final BeforeCallback callback) {
-		this.beforeCallback = callback;
+		super.before(callback);
 		return this;
 	}
 
 	@Override
 	@NonNull
 	public WriteRequest with(@NonNull final DataSentCallback callback) {
-		this.valueCallback = callback;
+		super.with(callback);
 		return this;
 	}
 

--- a/ble/src/main/java/no/nordicsemi/android/ble/callback/InvalidRequestCallback.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/callback/InvalidRequestCallback.java
@@ -20,27 +20,13 @@
  * USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package no.nordicsemi.android.ble;
+package no.nordicsemi.android.ble.callback;
 
-import android.support.annotation.NonNull;
+public interface InvalidRequestCallback {
 
-@SuppressWarnings({"unused", "WeakerAccess"})
-public final class SleepRequest extends Request {
-	private long delay;
-
-	SleepRequest(@NonNull final Type type, final long delay) {
-		super(type);
-		this.delay = delay;
-	}
-
-    @NonNull
-    @Override
-    SleepRequest setManager(@NonNull final BleManager manager) {
-        super.setManager(manager);
-        return this;
-    }
-
-	long getDelay() {
-		return delay;
-	}
+	/**
+	 * A callback invoked when the request was invalid, for example when was called before the
+	 * device was connected.
+	 */
+	void onInvalidRequest();
 }

--- a/ble/src/main/java/no/nordicsemi/android/ble/exception/InvalidRequestException.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/exception/InvalidRequestException.java
@@ -20,16 +20,24 @@
  * USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package no.nordicsemi.android.ble;
+package no.nordicsemi.android.ble.exception;
 
-import android.support.annotation.NonNull;
+import no.nordicsemi.android.ble.Request;
 
-public interface TaskQueue {
+@SuppressWarnings({"WeakerAccess", "unused"})
+public final class InvalidRequestException extends Exception {
+	private final Request request;
 
-    /**
-     * Enqueues a new request.
-     *
-     * @param request the new request to be added to the end of the queue.
-     */
-    void enqueue(@NonNull final Request request);
+	public InvalidRequestException(final Request request) {
+		super("Invalid request");
+		this.request = request;
+	}
+
+	/**
+	 * Returns the invalid request.
+	 * @return The invalid request.
+	 */
+	public Request getRequest() {
+		return request;
+	}
 }

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.4'
+        classpath 'com.android.tools.build:gradle:3.2.0'
         /*
         classpath "com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.3"
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.0'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Apr 11 10:30:46 CEST 2018
+#Fri Sep 28 10:10:09 CEST 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip


### PR DESCRIPTION
This PR fixes issue #27 and helps with #26.
The public API of the library changes. A new method `Request.invalid(InvalidRequestCallback)` has been added. It will be called if a non-connect request was invoked before the connect request, so the `BluetoothDevice` object is not known. Success and failure callbacks require the device object (`@NonNull`), so can't called. This situation is so rare (developer mus try to perform BLE operation before the device was connected), that this breaks the least. For synchronous calls a new Exception was added that must be handled, unfortunately.

Also, the connection now cancels automatically when terminated because of timeout.