### PR TITLE
Bugs fixes and other features

### DIFF
--- a/ble/src/main/java/no/nordicsemi/android/ble/BleManager.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/BleManager.java
@@ -298,8 +298,10 @@ public abstract class BleManager<E extends BleManagerCallbacks> implements ILogg
 					if (previousBondState == BluetoothDevice.BOND_BONDING) {
 						mCallbacks.onBondingFailed(device);
 						log(Level.WARNING, "Bonding failed");
-						if (mRequest != null) // CREATE_BOND request
+						if (mRequest != null) { // CREATE_BOND request
 							mRequest.notifyFail(device, FailCallback.REASON_REQUEST_FAILED);
+							mRequest = null;
+						}
 					} else if (previousBondState == BluetoothDevice.BOND_BONDED) {
 						if (mRequest != null && mRequest.type == Request.Type.REMOVE_BOND) {
 							// The device has already disconnected by now.
@@ -315,8 +317,10 @@ public abstract class BleManager<E extends BleManagerCallbacks> implements ILogg
 				case BluetoothDevice.BOND_BONDED:
 					log(Level.INFO, "Device bonded");
 					mCallbacks.onBonded(device);
-					if (mRequest != null && mRequest.type == Request.Type.CREATE_BOND)
+					if (mRequest != null && mRequest.type == Request.Type.CREATE_BOND) {
 						mRequest.notifySuccess(device);
+						mRequest = null;
+					}
 					// If the device started to pair just after the connection was
 					// established the services were not discovered.
 					if (!mServicesDiscovered && !mServiceDiscoveryRequested) {

--- a/ble/src/main/java/no/nordicsemi/android/ble/BleManager.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/BleManager.java
@@ -408,7 +408,7 @@ public abstract class BleManager<E extends BleManagerCallbacks> implements ILogg
 	 * @param context the context.
 	 */
 	public BleManager(@NonNull final Context context) {
-		mContext = context;
+		mContext = context.getApplicationContext();
 		mHandler = new Handler(Looper.getMainLooper());
 	}
 

--- a/ble/src/main/java/no/nordicsemi/android/ble/BleManager.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/BleManager.java
@@ -862,10 +862,8 @@ public abstract class BleManager<E extends BleManagerCallbacks> implements ILogg
 			 */
 			try {
 				final Method createBond = device.getClass().getMethod("createBond");
-				if (createBond != null) {
-					log(Level.DEBUG, "device.createBond() (hidden)");
-					return (Boolean) createBond.invoke(device);
-				}
+				log(Level.DEBUG, "device.createBond() (hidden)");
+				return (Boolean) createBond.invoke(device);
 			} catch (final Exception e) {
 				Log.w(TAG, "An exception occurred while creating bond", e);
 			}
@@ -912,10 +910,8 @@ public abstract class BleManager<E extends BleManagerCallbacks> implements ILogg
 		 */
 		try {
 			final Method removeBond = device.getClass().getMethod("removeBond");
-			if (removeBond != null) {
-				log(Level.DEBUG, "device.removeBond() (hidden)");
-				return (Boolean) removeBond.invoke(device);
-			}
+			log(Level.DEBUG, "device.removeBond() (hidden)");
+			return (Boolean) removeBond.invoke(device);
 		} catch (final Exception e) {
 			Log.w(TAG, "An exception occurred while removing bond", e);
 		}
@@ -1761,9 +1757,7 @@ public abstract class BleManager<E extends BleManagerCallbacks> implements ILogg
 		 */
 		try {
 			final Method refresh = gatt.getClass().getMethod("refresh");
-			if (refresh != null) {
-				return (Boolean) refresh.invoke(gatt);
-			}
+			return (Boolean) refresh.invoke(gatt);
 		} catch (final Exception e) {
 			Log.w(TAG, "An exception occurred while refreshing device", e);
 			log(Level.WARNING, "gatt.refresh() method not found");

--- a/ble/src/main/java/no/nordicsemi/android/ble/ConnectRequest.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/ConnectRequest.java
@@ -104,7 +104,7 @@ public class ConnectRequest extends Request {
 	@Override
 	@NonNull
 	public ConnectRequest before(@NonNull final BeforeCallback callback) {
-		this.beforeCallback = callback;
+		super.before(callback);
 		return this;
 	}
 

--- a/ble/src/main/java/no/nordicsemi/android/ble/ConnectRequest.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/ConnectRequest.java
@@ -22,7 +22,11 @@
 
 package no.nordicsemi.android.ble;
 
+import android.bluetooth.BluetoothAdapter;
 import android.bluetooth.BluetoothDevice;
+import android.bluetooth.BluetoothGatt;
+import android.bluetooth.BluetoothGattCallback;
+import android.content.Context;
 import android.support.annotation.NonNull;
 
 import no.nordicsemi.android.ble.callback.BeforeCallback;
@@ -52,11 +56,14 @@ public class ConnectRequest extends Request {
 
 	private BluetoothDevice device;
 	private int preferredPhy;
+	private int attempt = 0, retries = 0;
+	private int delay = 0;
+	private boolean autoConnect = false;
 
-	ConnectRequest(@NonNull final Type type, @NonNull final BluetoothDevice device, final int phy) {
+	ConnectRequest(@NonNull final Type type, @NonNull final BluetoothDevice device) {
 		super(type);
 		this.device = device;
-		this.preferredPhy = phy;
+		this.preferredPhy = PHY_LE_1M_MASK;
 	}
 
 	@NonNull
@@ -67,7 +74,7 @@ public class ConnectRequest extends Request {
 	}
 
 	/**
-	 * Use to add a completion callback. The callback will be invoked when the operation has
+	 * Use to set a completion callback. The callback will be invoked when the operation has
 	 * finished successfully unless {@link #await(int)} or its variant was used, in which case this
 	 * callback will be ignored.
 	 * <p>
@@ -108,11 +115,120 @@ public class ConnectRequest extends Request {
 		return this;
 	}
 
+	/**
+	 * Sets an optional retry count. The BleManager will do that many attempts to connect to the
+	 * device in case of an error. The library will not retry if the device is not reachable,
+	 * that is when the 30 sec timeout occurs.
+	 *
+	 * @param count how many times should the BleManager retry to connect.
+	 * @return The request.
+	 * @see #retry(int, int)
+	 */
+	public ConnectRequest retry(final int count) {
+		this.retries = count;
+		this.delay = 0;
+		return this;
+	}
+
+	/**
+	 * Sets an optional retry count and a delay that the process will wait before next connection
+	 * attempt. The library will not retry if the device is not reachable, that is when the 30 sec
+	 * timeout occurs.
+	 *
+	 * @param count how many times should the BleManager retry to connect.
+	 * @param delay the delay between each connection attempt.
+	 *              The real delay will be 200 ms longer than specified, as
+	 *              {@link BluetoothGatt#clone()} is estimated to last
+	 *              {@link BleManager#internalConnect(BluetoothDevice, ConnectRequest) 200 ms}.
+	 * @return The request.
+	 * @see #retry(int)
+	 */
+	public ConnectRequest retry(final int count, final int delay) {
+		this.retries = count;
+		this.delay = delay;
+		return this;
+	}
+
+	/**
+	 * This method replaces the {@link BleManager#shouldAutoConnect()} method.
+	 * <p>
+	 * Sets whether to connect to the remote device just once (false) or to add the address to
+	 * white list of devices that will be automatically connect as soon as they become available
+	 * (true). In the latter case, if Bluetooth adapter is enabled, Android scans periodically
+	 * for devices from the white list and, if an advertising packet is received from such, it tries
+	 * to connect to it. When the connection is lost, the system will keep trying to reconnect to
+	 * it. If method is called with parameter set to true, and the connection to the device is
+	 * lost, the {@link BleManagerCallbacks#onLinkLossOccurred(BluetoothDevice)} callback is
+	 * called instead of {@link BleManagerCallbacks#onDeviceDisconnected(BluetoothDevice)}.
+	 * <p>
+	 * This feature works much better on newer Android phone models and have issues on older
+	 * phones.
+	 * <p>
+	 * This method should only be used with bonded devices, as otherwise the device may change
+	 * it's address. It will however work also with non-bonded devices with private static address.
+	 * A connection attempt to a non-bonded device with private resolvable address will fail.
+	 * <p>
+	 * The first connection to a device will always be created with autoConnect flag to false
+	 * (see {@link BluetoothDevice#connectGatt(Context, boolean, BluetoothGattCallback)}). This is
+	 * to make it quick as the user most probably waits for a quick response. If autoConnect is
+	 * used (true), the following connections will be done using {@link BluetoothGatt#connect()},
+	 * which forces the autoConnect parameter to true.
+	 *
+	 * @param autoConnect true to use autoConnect feature on the second and following connections.
+	 *                    The first connection is always done with autoConnect parameter equal to
+	 *                    false, to make it faster and allow to timeout it the device is unreachable.
+	 * @return The request.
+	 */
+	public ConnectRequest useAutoConnect(final boolean autoConnect) {
+		this.autoConnect = autoConnect;
+		return this;
+	}
+
+	/**
+	 * Sets the preferred PHY used for connection. Th value should be a bitmask composed of
+	 * {@link #PHY_LE_1M_MASK}, {@link #PHY_LE_2M_MASK} or {@link #PHY_LE_CODED_MASK}.
+	 * <p>
+	 * Different PHYs are available only on more recent devices with Android 8+.
+	 * Check {@link BluetoothAdapter#isLe2MPhySupported()} and
+	 * {@link BluetoothAdapter#isLeCodedPhySupported()} if required PHYs are supported by this
+	 * Android device. The default PHY is {@link #PHY_LE_1M_MASK}.
+	 *
+	 * @param phy preferred PHY for connections to remote LE device. Bitwise OR of any of
+	 *            {@link ConnectRequest#PHY_LE_1M_MASK}, {@link ConnectRequest#PHY_LE_2M_MASK},
+	 *            and {@link ConnectRequest#PHY_LE_CODED_MASK}. This option does not take effect
+	 *            if {@code autoConnect} is set to true.
+	 * @return The request.
+	 */
+	public ConnectRequest usePreferredPhy(final int phy) {
+		this.preferredPhy = phy;
+		return this;
+	}
+
 	public BluetoothDevice getDevice() {
 		return device;
 	}
 
 	int getPreferredPhy() {
 		return preferredPhy;
+	}
+
+	boolean canRetry() {
+		if (retries > 0) {
+			retries -= 1;
+			return true;
+		}
+		return false;
+	}
+
+	boolean isFirstAttempt() {
+		return attempt++ == 0;
+	}
+
+	int getRetryDelay() {
+		return delay;
+	}
+
+	boolean shouldAutoConnect() {
+		return autoConnect;
 	}
 }

--- a/ble/src/main/java/no/nordicsemi/android/ble/ConnectionPriorityRequest.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/ConnectionPriorityRequest.java
@@ -86,14 +86,14 @@ public final class ConnectionPriorityRequest extends ValueRequest<ConnectionPrio
 	@Override
 	@NonNull
 	public ConnectionPriorityRequest done(@NonNull final SuccessCallback callback) {
-		this.successCallback = callback;
+		super.done(callback);
 		return this;
 	}
 
 	@Override
 	@NonNull
 	public ConnectionPriorityRequest fail(@NonNull final FailCallback callback) {
-		this.failCallback = callback;
+		super.fail(callback);
 		return this;
 	}
 
@@ -107,7 +107,7 @@ public final class ConnectionPriorityRequest extends ValueRequest<ConnectionPrio
 	@Override
 	@NonNull
 	public ConnectionPriorityRequest before(@NonNull final BeforeCallback callback) {
-		this.beforeCallback = callback;
+		super.before(callback);
 		return this;
 	}
 
@@ -116,7 +116,7 @@ public final class ConnectionPriorityRequest extends ValueRequest<ConnectionPrio
 	@NonNull
 	public ConnectionPriorityRequest with(@NonNull final ConnectionPriorityCallback callback) {
 		// The BluetoothGattCallback#onConnectionUpdated callback was introduced in Android Oreo.
-		this.valueCallback = callback;
+		super.with(callback);
 		return this;
 	}
 

--- a/ble/src/main/java/no/nordicsemi/android/ble/DisconnectRequest.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/DisconnectRequest.java
@@ -67,7 +67,7 @@ public class DisconnectRequest extends Request {
 	@Override
 	@NonNull
 	public DisconnectRequest before(@NonNull final BeforeCallback callback) {
-		this.beforeCallback = callback;
+		super.before(callback);
 		return this;
 	}
 }

--- a/ble/src/main/java/no/nordicsemi/android/ble/MainThreadBluetoothGattCallback.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/MainThreadBluetoothGattCallback.java
@@ -29,6 +29,7 @@ import android.bluetooth.BluetoothGattDescriptor;
 import android.os.Build;
 import android.os.Handler;
 import android.os.Looper;
+import android.support.annotation.Keep;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.RequiresApi;
@@ -170,10 +171,11 @@ abstract class MainThreadBluetoothGattCallback extends BluetoothGattCallback {
 		runOnUiThread(() -> onPhyUpdateSafe(gatt, txPhy, rxPhy, status));
 	}
 
-	// This method is still hidden in Android Oreo
+	// This method is hidden in Android Oreo and Pie
 	// @Override
 	@SuppressWarnings("unused")
 	@RequiresApi(api = Build.VERSION_CODES.O)
+	@Keep
 	public final void onConnectionUpdated(final BluetoothGatt gatt,
 										  final int interval, final int latency, final int timeout,
 										  final int status) {

--- a/ble/src/main/java/no/nordicsemi/android/ble/MtuRequest.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/MtuRequest.java
@@ -53,14 +53,14 @@ public final class MtuRequest extends ValueRequest<MtuCallback> {
 	@Override
 	@NonNull
 	public MtuRequest done(@NonNull final SuccessCallback callback) {
-		this.successCallback = callback;
+		super.done(callback);
 		return this;
 	}
 
 	@Override
 	@NonNull
 	public MtuRequest fail(@NonNull final FailCallback callback) {
-		this.failCallback = callback;
+		super.fail(callback);
 		return this;
 	}
 
@@ -74,14 +74,14 @@ public final class MtuRequest extends ValueRequest<MtuCallback> {
 	@Override
 	@NonNull
 	public MtuRequest before(@NonNull final BeforeCallback callback) {
-		this.beforeCallback = callback;
+		super.before(callback);
 		return this;
 	}
 
 	@Override
 	@NonNull
 	public MtuRequest with(@NonNull final MtuCallback callback) {
-		this.valueCallback = callback;
+		super.with(callback);
 		return this;
 	}
 

--- a/ble/src/main/java/no/nordicsemi/android/ble/PhyRequest.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/PhyRequest.java
@@ -100,14 +100,14 @@ public final class PhyRequest extends ValueRequest<PhyCallback> {
 	@Override
 	@NonNull
 	public PhyRequest done(@NonNull final SuccessCallback callback) {
-		this.successCallback = callback;
+		super.done(callback);
 		return this;
 	}
 
 	@Override
 	@NonNull
 	public PhyRequest fail(@NonNull final FailCallback callback) {
-		this.failCallback = callback;
+		super.fail(callback);
 		return this;
 	}
 
@@ -121,14 +121,14 @@ public final class PhyRequest extends ValueRequest<PhyCallback> {
 	@Override
 	@NonNull
 	public PhyRequest before(@NonNull final BeforeCallback callback) {
-		this.beforeCallback = callback;
+		super.before(callback);
 		return this;
 	}
 
 	@Override
 	@NonNull
 	public PhyRequest with(@NonNull final PhyCallback callback) {
-		this.valueCallback = callback;
+		super.with(callback);
 		return this;
 	}
 

--- a/ble/src/main/java/no/nordicsemi/android/ble/ReadRequest.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/ReadRequest.java
@@ -74,14 +74,14 @@ public final class ReadRequest extends ValueRequest<DataReceivedCallback> {
 	@Override
 	@NonNull
 	public ReadRequest done(@NonNull final SuccessCallback callback) {
-		this.successCallback = callback;
+		super.done(callback);
 		return this;
 	}
 
 	@Override
 	@NonNull
 	public ReadRequest fail(@NonNull final FailCallback callback) {
-		this.failCallback = callback;
+		super.fail(callback);
 		return this;
 	}
 
@@ -95,14 +95,14 @@ public final class ReadRequest extends ValueRequest<DataReceivedCallback> {
 	@Override
 	@NonNull
 	public ReadRequest before(@NonNull final BeforeCallback callback) {
-		this.beforeCallback = callback;
+		super.before(callback);
 		return this;
 	}
 
 	@Override
 	@NonNull
 	public ReadRequest with(@NonNull final DataReceivedCallback callback) {
-		this.valueCallback = callback;
+		super.with(callback);
 		return this;
 	}
 

--- a/ble/src/main/java/no/nordicsemi/android/ble/ReadRssiRequest.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/ReadRssiRequest.java
@@ -47,14 +47,14 @@ public final class ReadRssiRequest extends ValueRequest<RssiCallback> {
 	@Override
 	@NonNull
 	public ReadRssiRequest done(@NonNull final SuccessCallback callback) {
-		this.successCallback = callback;
+		super.done(callback);
 		return this;
 	}
 
 	@Override
 	@NonNull
 	public ReadRssiRequest fail(@NonNull final FailCallback callback) {
-		this.failCallback = callback;
+		super.fail(callback);
 		return this;
 	}
 
@@ -68,14 +68,14 @@ public final class ReadRssiRequest extends ValueRequest<RssiCallback> {
 	@Override
 	@NonNull
 	public ReadRssiRequest before(@NonNull final BeforeCallback callback) {
-		this.beforeCallback = callback;
+		super.before(callback);
 		return this;
 	}
 
 	@Override
 	@NonNull
 	public ReadRssiRequest with(@NonNull final RssiCallback callback) {
-		this.valueCallback = callback;
+		super.with(callback);
 		return this;
 	}
 

--- a/ble/src/main/java/no/nordicsemi/android/ble/Request.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/Request.java
@@ -136,15 +136,11 @@ public class Request {
 	 * just like any other request.
 	 *
 	 * @param device the device to connect to.
-	 * @param phy preferred PHY for connections to remote LE device. Bitwise OR of any of
-	 *             {@link ConnectRequest#PHY_LE_1M_MASK}, {@link ConnectRequest#PHY_LE_2M_MASK},
-	 *             and {@link ConnectRequest#PHY_LE_CODED_MASK}. This option does not take effect
-	 *             if {@code autoConnect} is set to true.
 	 * @return The new connect request.
 	 */
 	@NonNull
-	static ConnectRequest connect(@NonNull final BluetoothDevice device, final int phy) {
-		return new ConnectRequest(Type.CONNECT, device, phy);
+	static ConnectRequest connect(@NonNull final BluetoothDevice device) {
+		return new ConnectRequest(Type.CONNECT, device);
 	}
 
 	/**

--- a/ble/src/main/java/no/nordicsemi/android/ble/WaitForValueChangedRequest.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/WaitForValueChangedRequest.java
@@ -91,7 +91,7 @@ public class WaitForValueChangedRequest extends ValueRequest<DataReceivedCallbac
 	@Override
 	@NonNull
 	public WaitForValueChangedRequest before(@NonNull final BeforeCallback callback) {
-		this.beforeCallback = callback;
+		super.before(callback);
 		return this;
 	}
 


### PR DESCRIPTION
This PR fixes issues #16, #29, #30. Also adds some tweaks here and there.
It adds some a-bit-breaking changes: shoudlAutoConnect() methods is now a part of ConnectRequest. The old one has been deprecated, will work like before, but may be removed in some future clean-up version.
Also, the library will now automatically retry connection attempts in case of a connection error, like 133, but not when the device is unreachable (error 133 after 30 seconds). To enable it, call `connect(device).retry(count, delay).enqueue()`.