### PR TITLE
Notification filters

### DIFF
--- a/ble/src/main/java/no/nordicsemi/android/ble/BleManager.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/BleManager.java
@@ -1336,7 +1336,7 @@ public abstract class BleManager<E extends BleManagerCallbacks> extends TimeoutH
 	 */
 	@NonNull
 	protected WriteRequest writeCharacteristic(@Nullable final BluetoothGattCharacteristic characteristic,
-													 @Nullable final Data data) {
+											   @Nullable final Data data) {
 		return Request.newWriteRequest(characteristic, data != null ? data.getValue() : null)
 				.setManager(this);
 	}
@@ -1359,7 +1359,7 @@ public abstract class BleManager<E extends BleManagerCallbacks> extends TimeoutH
 	 */
 	@NonNull
 	protected WriteRequest writeCharacteristic(@Nullable final BluetoothGattCharacteristic characteristic,
-													 @Nullable final byte[] data) {
+											   @Nullable final byte[] data) {
 		return Request.newWriteRequest(characteristic, data).setManager(this);
 	}
 
@@ -1384,7 +1384,7 @@ public abstract class BleManager<E extends BleManagerCallbacks> extends TimeoutH
 	 */
 	@NonNull
 	protected WriteRequest writeCharacteristic(@Nullable final BluetoothGattCharacteristic characteristic,
-													 @Nullable final byte[] data, final int offset, final int length) {
+											   @Nullable final byte[] data, final int offset, final int length) {
 		return Request.newWriteRequest(characteristic, data, offset, length).setManager(this);
 	}
 
@@ -1451,7 +1451,7 @@ public abstract class BleManager<E extends BleManagerCallbacks> extends TimeoutH
 	 */
 	@NonNull
 	protected WriteRequest writeDescriptor(@Nullable final BluetoothGattDescriptor descriptor,
-												 @Nullable final Data data) {
+										   @Nullable final Data data) {
 		return Request.newWriteRequest(descriptor, data != null ? data.getValue() : null)
 				.setManager(this);
 	}
@@ -1474,7 +1474,7 @@ public abstract class BleManager<E extends BleManagerCallbacks> extends TimeoutH
 	 */
 	@NonNull
 	protected WriteRequest writeDescriptor(@Nullable final BluetoothGattDescriptor descriptor,
-												 @Nullable final byte[] data) {
+										   @Nullable final byte[] data) {
 		return Request.newWriteRequest(descriptor, data).setManager(this);
 	}
 
@@ -1498,8 +1498,8 @@ public abstract class BleManager<E extends BleManagerCallbacks> extends TimeoutH
 	 */
 	@NonNull
 	protected WriteRequest writeDescriptor(@Nullable final BluetoothGattDescriptor descriptor,
-												 @Nullable final byte[] data, final int offset,
-												 final int length) {
+										   @Nullable final byte[] data, final int offset,
+										   final int length) {
 		return Request.newWriteRequest(descriptor, data, offset, length).setManager(this);
 	}
 
@@ -1886,7 +1886,7 @@ public abstract class BleManager<E extends BleManagerCallbacks> extends TimeoutH
 	 * @return The request.
 	 */
 	protected PhyRequest setPreferredPhy(@PhyMask final int txPhy, @PhyMask final int rxPhy,
-											   @PhyOption final int phyOptions) {
+										 @PhyOption final int phyOptions) {
 		return Request.newSetPreferredPhyRequest(txPhy, rxPhy, phyOptions).setManager(this);
 	}
 

--- a/ble/src/main/java/no/nordicsemi/android/ble/BleManager.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/BleManager.java
@@ -2851,7 +2851,7 @@ public abstract class BleManager<E extends BleManagerCallbacks> extends TimeoutH
 				}
 				// Notify the notification registered listener, if set
 				final ValueChangedCallback request = mNotificationCallbacks.get(characteristic);
-				if (request != null) {
+				if (request != null && request.matches(data)) {
 					request.notifyValueChanged(gatt.getDevice(), data);
 				}
 				// If there is a value change request,
@@ -2861,7 +2861,9 @@ public abstract class BleManager<E extends BleManagerCallbacks> extends TimeoutH
 						&& valueChangedRequest.characteristic == characteristic
 						// and didn't have a trigger, or the trigger was started
 						// (not necessarily completed)
-						&& !valueChangedRequest.isTriggerPending()) {
+						&& !valueChangedRequest.isTriggerPending()
+						// and the data matches the filter (if set)
+						&& valueChangedRequest.matches(data)) {
 					// notify that new data was received.
 					valueChangedRequest.notifyValueChanged(gatt.getDevice(), data);
 

--- a/ble/src/main/java/no/nordicsemi/android/ble/BleManager.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/BleManager.java
@@ -2612,8 +2612,11 @@ public abstract class BleManager<E extends BleManagerCallbacks> extends TimeoutH
 				onCharacteristicRead(gatt, characteristic);
 				if (mRequest instanceof ReadRequest) {
 					final ReadRequest request = (ReadRequest) mRequest;
-					request.notifyValueChanged(gatt.getDevice(), data);
-					if (request.hasMore()) {
+					final boolean matches = request.matches(data);
+					if (matches) {
+						request.notifyValueChanged(gatt.getDevice(), data);
+					}
+					if (!matches || request.hasMore()) {
 						enqueueFirst(request);
 					} else {
 						request.notifySuccess(gatt.getDevice());

--- a/ble/src/main/java/no/nordicsemi/android/ble/ReadRequest.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/ReadRequest.java
@@ -37,6 +37,7 @@ import no.nordicsemi.android.ble.callback.ReadProgressCallback;
 import no.nordicsemi.android.ble.callback.SuccessCallback;
 import no.nordicsemi.android.ble.callback.profile.ProfileReadResponse;
 import no.nordicsemi.android.ble.data.Data;
+import no.nordicsemi.android.ble.data.DataFilter;
 import no.nordicsemi.android.ble.data.DataMerger;
 import no.nordicsemi.android.ble.data.DataStream;
 import no.nordicsemi.android.ble.exception.BluetoothDisabledException;
@@ -50,6 +51,7 @@ public final class ReadRequest extends SimpleValueRequest<DataReceivedCallback> 
 	private ReadProgressCallback progressCallback;
 	private DataMerger dataMerger;
 	private DataStream buffer;
+	private DataFilter filter;
 	private int count = 0;
 
 	ReadRequest(@NonNull final Type type) {
@@ -103,6 +105,18 @@ public final class ReadRequest extends SimpleValueRequest<DataReceivedCallback> 
 	@NonNull
 	public ReadRequest with(@NonNull final DataReceivedCallback callback) {
 		super.with(callback);
+		return this;
+	}
+
+	/**
+	 * Sets a filter which allows to skip some incoming data.
+	 *
+	 * @param filter the data filter.
+	 * @return The request.
+	 */
+	@NonNull
+	public ReadRequest filter(@NonNull final DataFilter filter) {
+		this.filter = filter;
 		return this;
 	}
 
@@ -199,6 +213,10 @@ public final class ReadRequest extends SimpleValueRequest<DataReceivedCallback> 
 			throw new InvalidDataException(response);
 		}
 		return response;
+	}
+
+	boolean matches(final byte[] packet) {
+		return filter == null || filter.filter(packet);
 	}
 
 	void notifyValueChanged(@NonNull final BluetoothDevice device, @Nullable final byte[] value) {

--- a/ble/src/main/java/no/nordicsemi/android/ble/ValueChangedCallback.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/ValueChangedCallback.java
@@ -29,6 +29,7 @@ import androidx.annotation.Nullable;
 import no.nordicsemi.android.ble.callback.DataReceivedCallback;
 import no.nordicsemi.android.ble.callback.ReadProgressCallback;
 import no.nordicsemi.android.ble.data.Data;
+import no.nordicsemi.android.ble.data.DataFilter;
 import no.nordicsemi.android.ble.data.DataMerger;
 import no.nordicsemi.android.ble.data.DataStream;
 
@@ -38,6 +39,7 @@ public class ValueChangedCallback {
 	private DataReceivedCallback valueCallback;
 	private DataMerger dataMerger;
 	private DataStream buffer;
+	private DataFilter filter;
 	private int count = 0;
 
 	ValueChangedCallback() {
@@ -54,6 +56,18 @@ public class ValueChangedCallback {
 	@NonNull
 	public ValueChangedCallback with(@NonNull final DataReceivedCallback callback) {
 		this.valueCallback = callback;
+		return this;
+	}
+
+	/**
+	 * Sets a filter which allows to skip some incoming data.
+	 *
+	 * @param filter the data filter.
+	 * @return The request.
+	 */
+	@NonNull
+	public ValueChangedCallback filter(@NonNull final DataFilter filter) {
+		this.filter = filter;
 		return this;
 	}
 
@@ -90,6 +104,10 @@ public class ValueChangedCallback {
 		progressCallback = null;
 		buffer = null;
 		return this;
+	}
+
+	boolean matches(final byte[] packet) {
+		return filter == null || filter.filter(packet);
 	}
 
 	void notifyValueChanged(@NonNull final BluetoothDevice device, @Nullable final byte[] value) {

--- a/ble/src/main/java/no/nordicsemi/android/ble/data/DataFilter.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/data/DataFilter.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2018, Nordic Semiconductor
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this
+ * software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+ * USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package no.nordicsemi.android.ble.data;
+
+import androidx.annotation.Nullable;
+
+public interface DataFilter {
+
+	/**
+	 * This method should return true if the packet matches the filter and should be processed
+	 * by the request.
+	 *
+	 * @param lastPacket the packet received.
+	 * @return True, if packet should be processed, false if it should be ignored.
+	 */
+	boolean filter(@Nullable final byte[] lastPacket);
+}


### PR DESCRIPTION
This PR fixes issue #63. A filter can now be assigned to `WaitForValueChangedRequest` and `ValueChangedCallback`, that will skip packets that will not be used to compose a message.