### PR TITLE
BluetoothGatt.close() wrapped in try-catch blocks

### DIFF
--- a/ble/src/main/java/no/nordicsemi/android/ble/BleManager.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/BleManager.java
@@ -771,7 +771,11 @@ public abstract class BleManager<E extends BleManagerCallbacks> extends TimeoutH
 				// have to close gatt and open it again.
 				if (!mInitialConnection) {
 					log(Log.DEBUG, "gatt.close()");
-					mBluetoothGatt.close();
+					try {
+						mBluetoothGatt.close();
+					} catch (final Throwable t) {
+						// ignore
+					}
 					mBluetoothGatt = null;
 					try {
 						log(Log.DEBUG, "wait(200)");
@@ -916,7 +920,11 @@ public abstract class BleManager<E extends BleManagerCallbacks> extends TimeoutH
 					}
 				}
 				log(Log.DEBUG, "gatt.close()");
-				mBluetoothGatt.close();
+				try {
+					mBluetoothGatt.close();
+				} catch (final Throwable t) {
+					// ignore
+				}
 				mBluetoothGatt = null;
 			}
 			mConnected = false;
@@ -2411,7 +2419,11 @@ public abstract class BleManager<E extends BleManagerCallbacks> extends TimeoutH
 				if (mBluetoothDevice == null) {
 					Log.e(TAG, "Device received notification after disconnection.");
 					log(Log.DEBUG, "gatt.close()");
-					gatt.close();
+					try {
+						gatt.close();
+					} catch (final Throwable t) {
+						// ignore
+					}
 					return;
 				}
 

--- a/ble/src/main/java/no/nordicsemi/android/ble/TimeoutableRequest.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/TimeoutableRequest.java
@@ -17,7 +17,7 @@ import no.nordicsemi.android.ble.exception.InvalidRequestException;
 import no.nordicsemi.android.ble.exception.RequestFailedException;
 
 @SuppressWarnings("WeakerAccess")
-abstract class TimeoutableRequest extends Request {
+public abstract class TimeoutableRequest extends Request {
 	private TimeoutHandler timeoutHandler;
 	private Runnable timeoutCallback;
 	private Handler handler;


### PR DESCRIPTION
This PR fixes #87.