### PR TITLE
GATT server support

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,63 @@
+## Changes in version 2.0:
+
+1. BLE operation methods (i.e. `writeCharacteristic(...)`, etc.) return the `Request` class now, 
+instead of boolean.
+2. `onLinklossOccur` callback has been renamed to `onLinkLossOccurred`.
+3. GATT callbacks (for example: `onCharacteristicRead`, `onCharacteristicNotified`, etc.) inside 
+`BleManagerGattCallback` has been deprecated. Use `Request` callbacks instead.
+4. Build-in Battery Level support has been deprecated. Request Battery Level as any other value.
+5. A new callbacks method: `onBondingFailed` has been added to `BleManagerCallbacks`.
+6. `shouldAutoConnect()` has ben deprecated, use `useAutoConnect(boolean)` in `ConnectRequest` instead.
+7. Timeout is supported for *connect*, *disconnect* and *wait for notification/indication*.
+Most BLE operations do not support setting timeout, as receiving the `BluetoothGattCallback` is required
+in order to perform the next operation.
+8. Atomic `RequestQueue` and `ReliableWriteRequest` are supported.  
+9. BLE Library 2.0 uses Java 8. There's no good reason for this except to push the ecosystem to 
+having this be a default. As of AGP 3.2 there is no reason not to do this
+(via [butterknife](https://github.com/JakeWharton/butterknife)).
+
+## Migration guide:
+
+1. Replace `initGatt(BluetoothGatt)` with `initialize()`:
+
+Old code:
+```java
+@Override
+protected Deque<Request> initGatt(final BluetoothGatt gatt) {
+  final LinkedList<Request> requests = new LinkedList<>();
+  requests.add(Request.newEnableNotificationsRequest(characteristic));
+  return requests;
+}
+```
+New code:
+```java
+@Override
+protected void initialize() {
+  setNotificationCallback(characteristic)
+    .with(new DataReceivedCallback() {
+      @Override
+      public void onDataReceived(@NonNull final BluetoothDevice device, @NonNull final Data data) {
+        ...
+      }
+    });
+  enableNotifications(characteristic)
+    .enqueue();
+}
+```
+
+See changes in [Android nRF Toolbox](https://github.com/NordicSemiconductor/Android-nRF-Toolbox/) 
+and [Android nRF Blinky](https://github.com/NordicSemiconductor/Android-nRF-Blinky/) for more examples.
+
+Remember to call `.enqueue()` method for initialization requests!
+
+Connect's completion callback is called after the initialization is done (without or with errors).
+
+2. Move your callback implementation from `BleManagerGattCallback` to request callbacks.
+3. To split logic from parsing, we recommend to extend `DataReceivedCallback` interface in a class 
+where your parse your data, and return higher-level values. For a sample, check out nRF Toolbox 
+and [Android BLE Common Library](https://github.com/NordicSemiconductor/Android-BLE-Common-Library/). 
+If you are depending on a SIG adopted profile, like Heart Rate Monitor, Proximity, etc., 
+feel free to include the **BLE Common Library** in your project. 
+It has all the parsers implemented. If your profile isn't there, we are happy to accept PRs.
+4. `connect()` and `disconnect()` methods also require calling `.enqueue()` in asynchronous use.
+5. Replace the `shouldAutoConnect()` method in the manager with `connect(device).useAutConnect(true).enqueue()/await()`.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Android BLE Library
 
-[ ![Download](https://api.bintray.com/packages/nordic/android/ble-library/images/download.svg) ](https://bintray.com/nordic/android/ble-library/_latestVersion)
+[ ![Download](https://api.bintray.com/packages/nordic/android/no.nordicsemi.android%3Able/images/download.svg) ](https://bintray.com/nordic/android/no.nordicsemi.android%3Able/_latestVersion)
 
 An Android library that solves a lot of Android's Bluetooth Low Energy problems. 
 The [BleManager](https://github.com/NordicSemiconductor/Android-BLE-Library/blob/master/ble/src/main/java/no/nordicsemi/android/ble/BleManager.java)

--- a/README.md
+++ b/README.md
@@ -60,17 +60,16 @@ project(':ble').projectDir = file('../Android-BLE-Library/ble')
 
 ## Usage
 
-`BleManager` may be used for a single connection 
-(see [nRF Toolbox](https://github.com/NordicSemiconductor/Android-nRF-Toolbox) -> RSC profile) 
-or when multiple connections are required (see nRF Toolbox -> Proximity profile), 
-from a Service (see nRF Toolbox -> RSC profile), ViewModel's repo 
-(see [Architecture Components](https://developer.android.com/topic/libraries/architecture/index.html) 
-and [nRF Blinky](https://github.com/NordicSemiconductor/Android-nRF-Blinky)),
-or as a singleton (not recommended, see nRF Toolbox -> HRM).
-
-A single `BleManager` instance is responsible for connecting and communicating with a single peripheral.
+A `BleManager` instance is responsible for connecting and communicating with a single peripheral.
 Multiple manager instances are allowed. Extend `BleManager` with you manager where you define the
 high level device's API.
+
+`BleManager` may be used in different ways:
+1. In a Service, for a single connection - see [nRF Toolbox](https://github.com/NordicSemiconductor/Android-nRF-Toolbox) -> RSC profile, 
+2. In a Service with multiple connections - see nRF Toolbox -> Proximity profile, 
+3. From ViewModel's repo - see [Architecture Components](https://developer.android.com/topic/libraries/architecture/index.html) 
+and [nRF Blinky](https://github.com/NordicSemiconductor/Android-nRF-Blinky)),
+4. As a singleton - not recommended, see nRF Toolbox -> HRM.
 
 ```java
 
@@ -182,8 +181,17 @@ class MyBleManager extends BleManager<BleManagerCallbacks> {
 					writeCharacteristic(secondCharacteristic, new byte[] { 01, 00 })
 						.done(device -> log(Log.INDO, "Power on command sent"))
 			 )
-			.with((device, data) -> log(Log.WARN, "Flux Capacitor enabled! Jumping to 1985 in 3 seconds!"))
+			.with((device, data) -> log(Log.WARN, "Flux Capacitor enabled! Going back to the future in 3 seconds!"))
 			.enqueue();
+		sleep(3000).enqueue();
+		write(secondCharacteristic, "Hold on!".getBytes())
+			.done(device -> log(Log.WARN, "It's 2140 again!"))
+			.enqueue();
+	}
+	
+	/** Aborts time travel. Call during 3 sec after enabling Flux Capacitor and only if you like 2020. */
+	public void abort() {
+		cancelQueue();
 	}
 }
 ```

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ The API is clean and easy to read.
 13. Operation timeouts (for *connect*, *disconnect* and *wait for notification* requests)
 14. Error handling
 15. Logging
+16. GATT server
 
 The library **does not provide support for scanning** for Bluetooth LE devices.
 For scanning, we recommend using 
@@ -71,68 +72,205 @@ A single `BleManager` instance is responsible for connecting and communicating w
 Multiple manager instances are allowed. Extend `BleManager` with you manager where you define the
 high level device's API.
 
-### Changes in version 2.0:
-
-1. BLE operation methods (i.e. `writeCharacteristic(...)`, etc.) return the `Request` class now, 
-instead of boolean.
-2. `onLinklossOccur` callback has been renamed to `onLinkLossOccurred`.
-3. GATT callbacks (for example: `onCharacteristicRead`, `onCharacteristicNotified`, etc.) inside 
-`BleManagerGattCallback` has been deprecated. Use `Request` callbacks instead.
-4. Build-in Battery Level support has been deprecated. Request Battery Level as any other value.
-5. A new callbacks method: `onBondingFailed` has been added to `BleManagerCallbacks`.
-6. `shouldAutoConnect()` has ben deprecated, use `useAutoConnect(boolean)` in `ConnectRequest` instead.
-7. Timeout is supported for *connect*, *disconnect* and *wait for notification/indication*.
-Most BLE operations do not support setting timeout, as receiving the `BluetoothGattCallback` is required
-in order to perform the next operation.
-8. Atomic `RequestQueue` and `ReliableWriteRequest` are supported.  
-9. BLE Library 2.0 uses Java 8. There's no good reason for this except to push the ecosystem to 
-having this be a default. As of AGP 3.2 there is no reason not to do this
-(via [butterknife](https://github.com/JakeWharton/butterknife)).
-
-#### Migration guide:
-
-1. Replace `initGatt(BluetoothGatt)` with `initialize()`:
-
-Old code:
 ```java
-@Override
-protected Deque<Request> initGatt(final BluetoothGatt gatt) {
-  final LinkedList<Request> requests = new LinkedList<>();
-  requests.add(Request.newEnableNotificationsRequest(characteristic));
-  return requests;
+
+class MyBleManager extends BleManager<BleManagerCallbacks> {
+	final static UUID SERVICE_UUID = UUID.fromString("XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX");
+	final static UUID FIRST_CHAR   = UUID.fromString("XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX");
+	final static UUID SECOND_CHAR  = UUID.fromString("XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX");
+
+	// Client characteristics
+	private BluetoothGattCharacteristic firstCharacteristic, secondCharacteristic;
+
+	MyBleManager(@NonNull final Context context) {
+		super(context);
+	}
+
+	@NonNull
+	@Override
+	protected BleManagerGattCallback getGattCallback() {
+		return gattCallback;
+	}
+
+	@Override
+	public void log(final int priority, @NonNull final String message) {
+		Log.println(priority, "MyBleManager", message);
+	}
+
+	/**
+	 * BluetoothGatt callbacks object.
+	 */
+	private final BleManagerGattCallback gattCallback = new BleManagerGattCallback() {
+
+		// This method will be called when the device is connected and services are discovered.
+		// You need to obtain references to the characteristics and descriptors that you will use.
+		// Return true if all required services are found, false otherwise.
+		@Override
+		public boolean isRequiredServiceSupported(@NonNull final BluetoothGatt gatt) {
+			final BluetoothGattService service = gatt.getService(SERVICE_UUID);
+			if (service != null) {
+				firstCharacteristic = service.getCharacteristic(FIRST_CHAR);
+				secondCharacteristic = service.getCharacteristic(SECOND_CHAR);
+			}
+			// Validate properties
+			boolean notify = false;
+			if (firstCharacteristic != null) {
+				final int properties = dataCharacteristic.getProperties();
+				notify = (properties & BluetoothGattCharacteristic.PROPERTY_NOTIFY) != 0;
+			}
+			boolean writeRequest = false;
+			if (secondCharacteristic != null) {
+				final int properties = controlPointCharacteristic.getProperties();
+				writeRequest = (properties & BluetoothGattCharacteristic.PROPERTY_WRITE) != 0;
+				secondCharacteristic.setWriteType(BluetoothGattCharacteristic.WRITE_TYPE_DEFAULT);
+			}
+			// Return true if all required services have been found
+			return firstCharacteristic != null && secondCharacteristic != null
+					&& notify && writeRequest;
+		}
+
+		// If you have any optional services, allocate them here. Return true only if
+		// they are found. 
+		@Override
+		protected boolean isOptionalServiceSupported(@NonNull final BluetoothGatt gatt) {
+			return super.isOptionalServiceSupported(gatt);
+		}
+
+		// Initialize your device here. Often you need to enable notifications and set required
+		// MTU or write some initial data. Do it here.
+		@Override
+		protected void initialize() {
+			// You may enqueue multiple operations. A queue ensures that all operations are 
+			// performed one after another, but it is not required.
+			beginAtomicRequestQueue()
+					.add(requestMtu(247) // Remember, GATT needs 3 bytes extra. This will allow packet size of 244 bytes.
+						.with((device, mtu) -> log(Log.INFO, "MTU set to " + mtu))
+						.fail((device, status) -> log(Log.WARN, "Requested MTU not supported: " + status)))
+					.add(setPreferredPhy(PhyRequest.PHY_LE_2M_MASK, PhyRequest.PHY_LE_2M_MASK, PhyRequest.PHY_OPTION_NO_PREFERRED)
+						.fail((device, status) -> log(Log.WARN, "Requested PHY not supported: " + status)))
+					.add(enableNotifications(firstCharacteristic))
+					.done(device -> log(Log.INFO, "Target initialized"))
+					.enqueue();			
+			// You may easily enqueue more operations here like such:
+			writeCharacteristic(secondCharacteristic, "Hello World!".getBytes())
+					.done(device -> log(Log.INFO, "Greetings sent"))
+					.enqueue();
+			// Set a callback for your notifications. You may also use waitForNotification(...).
+			// Both callbacks will be called when notification is received.
+			setNotificationCallback(firstCharacteristic, callback);
+			// If you need to send very long data using Write Without Response, use split()
+			// or define your own splitter in split(DataSplitter splitter, WriteProgressCallback cb). 
+			writeCharacteristic(secondCharacteristic, "Very, very long data that will no fit into MTU")
+					.split()
+					.enqueue();
+		}
+
+		@Override
+		protected void onDeviceDisconnected() {
+			// Device disconnected. Release your references here.
+			firstCharacteristic = null;
+			secondCharacteristic = null;
+		}
+	};
+	
+	// Define your API.
+	
+	/** Initialize time machine. */
+	public void enableFluxCapacitor() {
+		waitForNotification(firstCharacteristic)
+			.trigger(
+					writeCharacteristic(secondCharacteristic, new byte[] { 01, 00 })
+						.done(device -> log(Log.INDO, "Power on command sent"))
+			 )
+			.with((device, data) -> log(Log.WARN, "Flux Capacitor enabled! Jumping to 1985 in 3 seconds!"))
+			.enqueue();
+	}
 }
 ```
-New code:
+
+#### Adding GATT Server support
+
+Starting from version 2.2 you may now define and use the GATT server in the BLE Library.
+
+First, override a `BleServerManager` class and override `initializeServer()` method. Some helper
+methods, like `characteristic(...)`, `descriptor(...)` and their shared counterparts were created 
+for making the initialization more readable.
+
 ```java
-@Override
-protected void initialize() {
-  setNotificationCallback(characteristic)
-    .with(new DataReceivedCallback() {
-      @Override
-      public void onDataReceived(@NonNull final BluetoothDevice device, @NonNull final Data data) {
-        ...
-      }
-    });
-  enableNotifications(characteristic)
-    .enqueue();
+public class ServerManager extends BleServerManager<BleServerManagerCallbacks> {
+
+	ServerManager(@NonNull final Context context) {
+		super(context);
+	}
+
+	@NonNull
+	@Override
+	protected List<BluetoothGattService> initializeServer() {
+		return Collections.singletonList(
+				service(SERVICE_UUID,
+				characteristic(CHAR_UUID,
+						BluetoothGattCharacteristic.PROPERTY_WRITE // properties
+								| BluetoothGattCharacteristic.PROPERTY_NOTIFY
+								| BluetoothGattCharacteristic.PROPERTY_EXTENDED_PROPS,
+						BluetoothGattCharacteristic.PERMISSION_WRITE, // permissions
+						null, // initial data
+						cccd(), reliableWrite(), description("Some description", false) // descriptors
+				))
+		);
+	}
 }
 ```
-See changes in [Android nRF Toolbox](https://github.com/NordicSemiconductor/Android-nRF-Toolbox/) 
-and [Android nRF Blinky](https://github.com/NordicSemiconductor/Android-nRF-Blinky/) for more examples.
+Instantiate the server and set the callback listener:
+```java
+final ServerManager serverManager = new ServerManager(context);
+serverManager.setManagerCallbacks(this);
+```
+Set the server manager for each client connection:
+```java
+final MyBleManager manager = new MyBleManager(context);
+manager.setManagerCallbacks(this);
+// Use the manager with the server
+manager.useServer(serverManager);
+```
+The `BleServermanagerCallbacks.onServerReady()` will be invoked when all service were added.
+You may initiate your connection there.
 
-Remember to call `.enqueue()` method for initialization requests!
+In your client manager class, override the following method:
+```java
+class MyBleManager extends BleManager<BleManagerCallbacks> {
+	// [...]	
 
-Connect's completion callback is called after the initialization is done (without or with errors).
+	// Server characteristics
+	private BluetoothGattCharacteristic serverCharacteristic;
 
-2. Move your callback implementation from `BleManagerGattCallback` to request callbacks.
-3. To split logic from parsing, we recommend to extend `DataReceivedCallback` interface in a class 
-where your parse your data, and return higher-level values. For a sample, check out nRF Toolbox 
-and [Android BLE Common Library](https://github.com/NordicSemiconductor/Android-BLE-Common-Library/). 
-If you are depending on a SIG adopted profile, like Heart Rate Monitor, Proximity, etc., 
-feel free to include the **BLE Common Library** in your project. 
-It has all the parsers implemented. If your profile isn't there, we are happy to accept PRs.
-4. `connect()` and `disconnect()` methods also require calling `.enqueue()` in asynchronous use.
-5. Replace the `shouldAutoConnect()` method in the manager with `connect(device).useAutConnect(true).enqueue()/await()`.
+	// [...]
+
+	/**
+	 * BluetoothGatt callbacks object.
+	 */
+	private final BleManagerGattCallback gattCallback = new BleManagerGattCallback() {
+		// [...]	
+	
+		@Override
+		protected void onServerReady(@NonNull final BluetoothGattServer server) {
+			// Obtain your server attributes.
+			serverCharacteristic = server
+					.getService(SERVICE_UUID)
+					.getCharacteristic(CHAR_UUID);
+		}
+		
+		// [...]
+
+		@Override
+		protected void onDeviceDisconnected() {
+			// [...]
+			serverCharacteristic = null;
+		}
+	};
+	
+	// [...]
+}
+``` 
 
 #### How to test it:
 
@@ -143,7 +281,7 @@ The latter one is a set of useful parsers and callbacks for common Bluetooth SIG
 The libraries are available on jcenter, but if you need to make some changes, clone all 3 projects, 
 ensure the path to *:ble* and *:ble-common* modules are correct in *settings.gradle* file, and sync the project.
 
-## How to use it
+## Examples
 
 Find the simple example here [Android nRF Blinky](https://github.com/NordicSemiconductor/Android-nRF-Blinky).
 
@@ -159,3 +297,5 @@ classes in [nRF Toolbox](https://github.com/NordicSemiconductor/Android-nRF-Tool
 
 The BLE library v 1.x is no longer supported. Please migrate to 2.x for bug fixing releases.
 Find it on [version/1x branch](https://github.com/NordicSemiconductor/Android-BLE-Library/tree/version/1x).
+
+Migration guide is available [here](MIGRATION.md).

--- a/ble/build.gradle
+++ b/ble/build.gradle
@@ -31,7 +31,7 @@ ext {
 }
 */
 android {
-    compileSdkVersion 28
+    compileSdkVersion 29
 
     defaultConfig {
         minSdkVersion 18

--- a/ble/build.gradle
+++ b/ble/build.gradle
@@ -35,7 +35,7 @@ android {
 
     defaultConfig {
         minSdkVersion 18
-        targetSdkVersion 28
+        targetSdkVersion 29
         versionCode 27
         versionName "2.1.1"
 

--- a/ble/build.gradle
+++ b/ble/build.gradle
@@ -1,35 +1,5 @@
 apply plugin: 'com.android.library'
-/*
-apply plugin: 'com.github.dcendents.android-maven'
-apply plugin: 'com.jfrog.bintray'
 
-ext {
-    PUBLISH_GROUP_ID = 'no.nordicsemi.android'
-    PUBLISH_ARTIFACT_ID = 'ble'
-    PUBLISH_VERSION = '2.1.1'
-
-    bintrayRepo = 'android'
-    bintrayName = 'ble-library'
-
-    publishedGroupId = PUBLISH_GROUP_ID
-    artifact = PUBLISH_ARTIFACT_ID
-    libraryVersion = PUBLISH_VERSION
-    libraryName = 'BLE Library'
-    libraryDescription = 'Bluetooth Low Energy library for Android'
-
-    issuesUrl = 'https://github.com/NordicSemiconductor/Android-BLE-Library/issues'
-    siteUrl = 'https://github.com/NordicSemiconductor/Android-BLE-Library'
-    gitUrl = 'https://github.com/NordicSemiconductor/Android-BLE-Library.git'
-
-    developerId = 'philips77'
-    developerName = 'Aleksander Nowakowski'
-    developerEmail = 'aleksander.nowakowski@nordicsemi.no'
-
-    licenseName = 'The BSD 3-Clause License'
-    licenseUrl = 'http://opensource.org/licenses/BSD-3-Clause'
-    allLicenses = ["BSD 3-Clause"]
-}
-*/
 android {
     compileSdkVersion 29
 
@@ -37,7 +7,7 @@ android {
         minSdkVersion 18
         targetSdkVersion 29
         versionCode 27
-        versionName "2.1.1"
+        versionName VERSION_NAME
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
@@ -64,55 +34,4 @@ dependencies {
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
 }
 
-/*
-// The following script creates a POM file required to publish on Maven Central
-apply from: 'https://raw.githubusercontent.com/nuuneoi/JCenter/master/installv1.gradle'
-
-// This script creates sources and javadocs. Both are required to publish a library on jcenter and MC.
-apply from: 'https://raw.githubusercontent.com/ArthurHub/release-android-library/master/android-release-aar.gradle'
-
-// The following link publishes the library to jcenter. It does not handle the userOrg, so it has been copied and modified below.
-//apply from: 'https://raw.githubusercontent.com/nuuneoi/JCenter/master/bintrayv1.gradle'
-
-// Copied from https://raw.githubusercontent.com/nuuneoi/JCenter/master/bintrayv1.gradle
-version = libraryVersion
-
-// Bintray
-Properties properties = new Properties()
-properties.load(project.rootProject.file('local.properties').newDataInputStream())
-
-bintray {
-    user = properties.getProperty("bintray.user")
-    key = properties.getProperty("bintray.apikey")
-
-    configurations = ['archives']
-    pkg {
-        repo = bintrayRepo
-        name = bintrayName
-        userOrg = properties.getProperty("bintray.userOrg")
-        desc = libraryDescription
-        websiteUrl = siteUrl
-        issueTrackerUrl = issuesUrl
-        vcsUrl = gitUrl
-        licenses = allLicenses
-        publish = true
-        publicDownloadNumbers = true
-        version {
-            desc = libraryDescription
-            gpg {
-                sign = true //Determines whether to GPG sign the files. The default is false
-                passphrase = properties.getProperty("bintray.gpg.password")
-                //Optional. The passphrase for GPG signing'
-            }
-        }
-    }
-}
-
-if (JavaVersion.current().isJava8Compatible()) {
-    allprojects {
-        tasks.withType(Javadoc) {
-            options.addStringOption('Xdoclint:none', '-quiet')
-        }
-    }
-}
-*/
+apply from: rootProject.file('gradle/gradle-bintray-push.gradle')

--- a/ble/gradle.properties
+++ b/ble/gradle.properties
@@ -1,0 +1,3 @@
+POM_ARTIFACT_ID=ble
+POM_NAME=Bluetooth Low Energy library for Android
+POM_PACKAGING=aar

--- a/ble/src/main/java/no/nordicsemi/android/ble/AwaitingRequest.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/AwaitingRequest.java
@@ -86,6 +86,7 @@ public class AwaitingRequest<T> extends TimeoutableValueRequest<T> {
 		return trigger;
 	}
 
+	@SuppressWarnings("BooleanMethodIsAlwaysInverted")
 	boolean isTriggerPending() {
 		return triggerStatus == NOT_STARTED;
 	}

--- a/ble/src/main/java/no/nordicsemi/android/ble/AwaitingRequest.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/AwaitingRequest.java
@@ -1,0 +1,96 @@
+package no.nordicsemi.android.ble;
+
+import android.bluetooth.BluetoothGatt;
+import android.bluetooth.BluetoothGattCharacteristic;
+import android.bluetooth.BluetoothGattDescriptor;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import no.nordicsemi.android.ble.exception.BluetoothDisabledException;
+import no.nordicsemi.android.ble.exception.DeviceDisconnectedException;
+import no.nordicsemi.android.ble.exception.InvalidRequestException;
+import no.nordicsemi.android.ble.exception.RequestFailedException;
+
+public class AwaitingRequest<T> extends TimeoutableValueRequest<T> {
+	private static final int NOT_STARTED = -123456;
+	private static final int STARTED = NOT_STARTED + 1;
+
+	private Request trigger;
+	private int triggerStatus = BluetoothGatt.GATT_SUCCESS;
+
+	AwaitingRequest(@NonNull final Type type, @Nullable final BluetoothGattCharacteristic characteristic) {
+		super(type, characteristic);
+	}
+
+	AwaitingRequest(@NonNull final Type type, @Nullable final BluetoothGattDescriptor descriptor) {
+		super(type, descriptor);
+	}
+
+	/**
+	 * Sets an optional request that is suppose to trigger the notification or indication.
+	 * This is to ensure that the characteristic value won't change before the callback was set.
+	 *
+	 * @param trigger the operation that triggers the notification, usually a write characteristic
+	 *                request that write some OP CODE.
+	 * @return The request.
+	 */
+	@NonNull
+	public AwaitingRequest trigger(@NonNull final Operation trigger) {
+		if (trigger instanceof Request) {
+			this.trigger = (Request) trigger;
+			this.triggerStatus = NOT_STARTED;
+			// The trigger will never receive invalid request event.
+			// If the BluetoothDevice wasn't set, the whole WaitForValueChangedRequest would be invalid.
+			/*this.trigger.invalid(() -> {
+				// never called
+			});*/
+			this.trigger.internalBefore(device -> triggerStatus = STARTED);
+			this.trigger.internalSuccess(device -> triggerStatus = BluetoothGatt.GATT_SUCCESS);
+			this.trigger.internalFail((device, status) -> {
+				triggerStatus = status;
+				syncLock.open();
+				notifyFail(device, status);
+			});
+		}
+		return this;
+	}
+
+	@NonNull
+	@Override
+	public <E extends T> E await(@NonNull final E response)
+			throws RequestFailedException, DeviceDisconnectedException, BluetoothDisabledException,
+			InvalidRequestException, InterruptedException {
+		assertNotMainThread();
+
+		try {
+			// Ensure the trigger request it enqueued after the callback has been set.
+			if (trigger != null && trigger.enqueued) {
+				throw new IllegalStateException("Trigger request already enqueued");
+			}
+			super.await(response);
+			return response;
+		} catch (final RequestFailedException e) {
+			if (triggerStatus != BluetoothGatt.GATT_SUCCESS) {
+				// Trigger will never have invalid request status. The outer request will.
+				/*if (triggerStatus == RequestCallback.REASON_REQUEST_INVALID) {
+					throw new InvalidRequestException(trigger);
+				}*/
+				throw new RequestFailedException(trigger, triggerStatus);
+			}
+			throw e;
+		}
+	}
+
+	@Nullable
+	Request getTrigger() {
+		return trigger;
+	}
+
+	boolean isTriggerPending() {
+		return triggerStatus == NOT_STARTED;
+	}
+
+	boolean isTriggerCompleteOrNull() {
+		return triggerStatus != STARTED;
+	}
+}

--- a/ble/src/main/java/no/nordicsemi/android/ble/AwaitingRequest.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/AwaitingRequest.java
@@ -11,12 +11,16 @@ import no.nordicsemi.android.ble.exception.DeviceDisconnectedException;
 import no.nordicsemi.android.ble.exception.InvalidRequestException;
 import no.nordicsemi.android.ble.exception.RequestFailedException;
 
-public class AwaitingRequest<T> extends TimeoutableValueRequest<T> {
+public abstract class AwaitingRequest<T> extends TimeoutableValueRequest<T> {
 	private static final int NOT_STARTED = -123456;
 	private static final int STARTED = NOT_STARTED + 1;
 
 	private Request trigger;
 	private int triggerStatus = BluetoothGatt.GATT_SUCCESS;
+
+	AwaitingRequest(@NonNull final Type type) {
+		super(type);
+	}
 
 	AwaitingRequest(@NonNull final Type type, @Nullable final BluetoothGattCharacteristic characteristic) {
 		super(type, characteristic);

--- a/ble/src/main/java/no/nordicsemi/android/ble/BleManager.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/BleManager.java
@@ -116,7 +116,8 @@ public abstract class BleManager<E extends BleManagerCallbacks> implements ILogg
 	private final Handler handler;
 	private BleServerManager serverManager;
 	BleManager.BleManagerGattCallback requestHandler;
-	E userCallbacks;
+	/** Manager callbacks, set using {@link #setManagerCallbacks(BleManagerCallbacks)}. */
+	protected E callbacks;
 
 	private final BroadcastReceiver mPairingRequestBroadcastReceiver = new BroadcastReceiver() {
 		@Override
@@ -212,7 +213,7 @@ public abstract class BleManager<E extends BleManagerCallbacks> implements ILogg
 	 * @param callbacks the callback listener.
 	 */
 	public final void setManagerCallbacks(@NonNull final E callbacks) {
-		userCallbacks = callbacks;
+		this.callbacks = callbacks;
 	}
 
 	/**
@@ -222,7 +223,7 @@ public abstract class BleManager<E extends BleManagerCallbacks> implements ILogg
 	 *
 	 * @param server the server instance.
 	 */
-	public final <S extends BleServerManagerCallbacks> void useServer(@NonNull final BleServerManager<S> server) {
+	public final void useServer(@NonNull final BleServerManager server) {
 		if (serverManager != null) {
 			serverManager.removeManager(this);
 		}
@@ -492,7 +493,7 @@ public abstract class BleManager<E extends BleManagerCallbacks> implements ILogg
 	@SuppressWarnings("ConstantConditions")
 	@NonNull
 	public final ConnectRequest connect(@NonNull final BluetoothDevice device) {
-		if (userCallbacks == null) {
+		if (callbacks == null) {
 			throw new NullPointerException("Set callbacks using setManagerCallbacks(E callbacks) before connecting");
 		}
 		if (device == null) {
@@ -542,7 +543,7 @@ public abstract class BleManager<E extends BleManagerCallbacks> implements ILogg
 	@NonNull
 	@Deprecated
 	public final ConnectRequest connect(@NonNull final BluetoothDevice device, @PhyMask final int phy) {
-		if (userCallbacks == null) {
+		if (callbacks == null) {
 			throw new NullPointerException("Set callbacks using setManagerCallbacks(E callbacks) before connecting");
 		}
 		if (device == null) {
@@ -1743,7 +1744,6 @@ public abstract class BleManager<E extends BleManagerCallbacks> implements ILogg
 	 * The GATT Callback handler. An object of this class must be returned by
 	 * {@link #getGattCallback()}. It is responsible for all GATT operations.
 	 */
-	@SuppressWarnings({"WeakerAccess"})
 	protected abstract class BleManagerGattCallback extends BleManagerHandler {
 		// All methods defined in the super class.
 	}

--- a/ble/src/main/java/no/nordicsemi/android/ble/BleManager.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/BleManager.java
@@ -62,7 +62,7 @@ import no.nordicsemi.android.ble.utils.ParserUtils;
 /**
  * <p>
  * The BleManager is responsible for managing the low level communication with a Bluetooth LE device.
- * Please see profiles thisementation in Android nRF Blinky or Android nRF Toolbox app for an
+ * Please see profiles implementation in Android nRF Blinky or Android nRF Toolbox app for an
  * example of use.
  * <p>
  * This base manager has been tested against number of devices and samples from Nordic SDK.

--- a/ble/src/main/java/no/nordicsemi/android/ble/BleManager.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/BleManager.java
@@ -1726,7 +1726,14 @@ public abstract class BleManager<E extends BleManagerCallbacks> implements ILogg
 	}
 
 	/**
-	 * Removes all enqueued requests from the queue. Initialization queue will not be impacted.
+	 * Removes all enqueued requests from the queue.
+	 * The currently executed request will be cancelled and will fail with status
+	 * {@link FailCallback#REASON_CANCELLED}.
+	 * <p>
+	 * If a BLE operation was in progress when the queue was cancelled, enqueueing a next BLE
+	 * operation immediately may cause the Bluetooth to behave improperly, as the manager will
+	 * try to execute it without waiting for the {@link BluetoothGattCallback callback}. A delay
+	 * in such case is recommended.
 	 */
 	protected final void cancelQueue() {
 		requestHandler.cancelQueue();

--- a/ble/src/main/java/no/nordicsemi/android/ble/BleManager.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/BleManager.java
@@ -1718,11 +1718,18 @@ public abstract class BleManager<E extends BleManagerCallbacks> implements ILogg
 	 * Enqueues a new request.
 	 *
 	 * @param request the new request to be added to the end of the queue.
-	 * @deprecated The access modifier of this method will be changed to package only.
+	 * @deprecated This way of enqueueing requests is deprecated, use above methods instead.
 	 */
 	@Deprecated
 	protected final void enqueue(@NonNull final Request request) {
 		requestHandler.enqueue(request);
+	}
+
+	/**
+	 * Removes all enqueued requests from the queue. Initialization queue will not be impacted.
+	 */
+	protected final void cancelQueue() {
+		requestHandler.cancelQueue();
 	}
 
 	/**

--- a/ble/src/main/java/no/nordicsemi/android/ble/BleManagerCallbacks.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/BleManagerCallbacks.java
@@ -69,8 +69,8 @@ public interface BleManagerCallbacks {
 	/**
 	 * Called when the device has disconnected (when the callback returned
 	 * {@link BluetoothGattCallback#onConnectionStateChange(BluetoothGatt, int, int)} with state
-	 * DISCONNECTED), but ONLY if the {@link BleManager#shouldAutoConnect()} method returned false
-	 * for this device when it was connecting.
+	 * DISCONNECTED), but ONLY if the {@link ConnectRequest#shouldAutoConnect()} method returned
+	 * false for this device when it was connecting.
 	 * Otherwise the {@link #onLinkLossOccurred(BluetoothDevice)} method will be called instead.
 	 *
 	 * @param device the device that got disconnected.
@@ -79,7 +79,7 @@ public interface BleManagerCallbacks {
 
 	/**
 	 * This callback is invoked when the Ble Manager lost connection to a device that has been
-	 * connected with autoConnect option (see {@link BleManager#shouldAutoConnect()}.
+	 * connected with autoConnect option (see {@link ConnectRequest#shouldAutoConnect()}.
 	 * Otherwise a {@link #onDeviceDisconnected(BluetoothDevice)} method will be called on such
 	 * event.
 	 *

--- a/ble/src/main/java/no/nordicsemi/android/ble/BleServerManager.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/BleServerManager.java
@@ -1,0 +1,397 @@
+package no.nordicsemi.android.ble;
+
+import android.bluetooth.BluetoothDevice;
+import android.bluetooth.BluetoothGatt;
+import android.bluetooth.BluetoothGattCharacteristic;
+import android.bluetooth.BluetoothGattDescriptor;
+import android.bluetooth.BluetoothGattServer;
+import android.bluetooth.BluetoothGattServerCallback;
+import android.bluetooth.BluetoothGattService;
+import android.bluetooth.BluetoothManager;
+import android.content.Context;
+import android.util.Log;
+
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Queue;
+import java.util.UUID;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.StringRes;
+import no.nordicsemi.android.ble.utils.ILogger;
+
+/**
+ * The manager for local GATT server. To be used with one or more instances of {@link BleManager}
+ *
+ * @since 2.2
+ */
+@SuppressWarnings({"WeakerAccess", "unused"})
+public abstract class BleServerManager<E extends BleServerManagerCallbacks> implements ILogger {
+	final static UUID CLIENT_USER_DESCRIPTION_DESCRIPTOR_UUID      = UUID.fromString("00002901-0000-1000-8000-00805f9b34fb");
+	final static UUID CLIENT_CHARACTERISTIC_CONFIG_DESCRIPTOR_UUID = UUID.fromString("00002902-0000-1000-8000-00805f9b34fb");
+
+	/** Bluetooth GATT server instance, or null if not opened. */
+	private BluetoothGattServer server;
+
+	private final List<BleManager> managers = new ArrayList<>();
+	private final Context context;
+	private E userCallbacks;
+
+	/**
+	 * List of server services returned by {@link #initializeServer()}.
+	 * This list is empties when the services are being added one by one to the server.
+	 * To get the server services, use {@link BluetoothGattServer#getServices()} instead.
+	 */
+	private Queue<BluetoothGattService> serverServices;
+
+	private List<BluetoothGattCharacteristic> sharedCharacteristics;
+	private List<BluetoothGattDescriptor> sharedDescriptors;
+
+	public BleServerManager(@NonNull final Context context) {
+		this.context = context;
+	}
+
+	/**
+	 * Opens the GATT server and starts initializing services. This method only starts initializing
+	 * services. The {@link BleServerManagerCallbacks#onServerReady()} will be called when all
+	 * services are done.
+	 *
+	 * @return true, if the server has been started successfully. If GATT server could not
+	 * be started, for example the Bluetooth is disabled, false is returned.
+	 * @see #close()
+	 */
+	public final boolean open() {
+		if (server != null)
+			return true;
+
+		serverServices = new LinkedList<>(initializeServer());
+		final BluetoothManager bm = (BluetoothManager) context.getSystemService(Context.BLUETOOTH_SERVICE);
+		if (bm != null) {
+			server = bm.openGattServer(context, gattServerCallback);
+		}
+		if (server != null) {
+			log(Log.INFO, "[Server] Server started successfully");
+			try {
+				final BluetoothGattService service = serverServices.remove();
+				server.addService(service);
+			} catch (final NoSuchElementException e) {
+				if (userCallbacks != null)
+					userCallbacks.onServerReady();
+			} catch (final Exception e) {
+				close();
+				return false;
+			}
+			return true;
+		}
+		log(Log.WARN, "GATT server initialization failed");
+		serverServices = null;
+		return false;
+	}
+
+	/**
+	 * Closes the GATT server.
+	 */
+	public final void close() {
+		if (server != null) {
+			server.close();
+			server = null;
+		}
+		serverServices = null;
+		for (BleManager manager: managers) {
+			manager.close();
+		}
+		managers.clear();
+	}
+
+	/**
+	 * Sets the manager callback listener.
+	 *
+	 * @param callbacks the callback listener.
+	 */
+	public final void setManagerCallbacks(@NonNull final E callbacks) {
+		userCallbacks = callbacks;
+	}
+
+	@Nullable
+	final BluetoothGattServer getServer() {
+		return server;
+	}
+
+	final void addManager(@NonNull final BleManager manager) {
+		if (!managers.contains(manager)) {
+			managers.add(manager);
+		}
+	}
+
+	final void removeManager(@NonNull final BleManager manager) {
+		managers.remove(manager);
+	}
+
+	@Nullable
+	private BleManagerHandler getRequestHandler(@NonNull final BluetoothDevice device) {
+		for (final BleManager manager : managers) {
+			if (device.equals(manager.getBluetoothDevice())) {
+				return manager.requestHandler;
+			}
+		}
+		return null;
+	}
+
+	@Override
+	public void log(final int priority, @NonNull final String message) {
+		// Override to log events. Simple log can use Logcat:
+		//
+		// Log.println(priority, TAG, message);
+		//
+		// You may also use Timber:
+		//
+		// Timber.log(priority, message);
+		//
+		// or nRF Logger:
+		//
+		// Logger.log(logSession, LogContract.Log.Level.fromPriority(priority), message);
+		//
+		// Starting from nRF Logger 2.1.3, you may use log-timber and plant nRFLoggerTree.
+		// https://github.com/NordicSemiconductor/nRF-Logger-API
+	}
+
+	@Override
+	public void log(final int priority, @StringRes final int messageRes,
+					@Nullable final Object... params) {
+		final String message = context.getString(messageRes, params);
+		log(priority, message);
+	}
+
+	/**
+	 * This method is called once, just after instantiating the {@link BleServerManager}.
+	 * It should return a list of server GATT services that will be available for the remote device
+	 * to use.
+	 * <p>
+	 * Server services will be added to the local GATT configuration on the Android device.
+	 * The library does not know what services are already set up by other apps or
+	 * {@link BleServerManager} instances, so a UUID collision is possible.
+	 * The remote device will discover all services set up by all apps.
+	 * <p>
+	 * In order to enable server callbacks (see {@link android.bluetooth.BluetoothGattServerCallback}),
+	 * but without defining own services, return an empty list.
+	 *
+	 * @since 2.2
+	 * @return The list of server GATT services, or null if no services should be created. An
+	 * empty array to start the GATT server without any services.
+	 */
+	@NonNull
+	protected abstract List<BluetoothGattService> initializeServer();
+
+	@NonNull
+	protected final BluetoothGattService service(@NonNull final UUID uuid, final BluetoothGattCharacteristic... characteristics) {
+		final BluetoothGattService service = new BluetoothGattService(uuid, BluetoothGattService.SERVICE_TYPE_PRIMARY);
+		for (BluetoothGattCharacteristic characteristic : characteristics) {
+			service.addCharacteristic(characteristic);
+		}
+		return service;
+	}
+
+	@NonNull
+	protected final BluetoothGattCharacteristic characteristic(@NonNull final UUID uuid,
+															   final int properties, final int permissions,
+															   @Nullable final byte[] initialValue,
+															   final BluetoothGattDescriptor... descriptors) {
+		final BluetoothGattCharacteristic characteristic = new BluetoothGattCharacteristic(uuid, properties, permissions);
+		for (BluetoothGattDescriptor descriptor: descriptors) {
+			characteristic.addDescriptor(descriptor);
+		}
+		characteristic.setValue(initialValue);
+		return characteristic;
+	}
+
+	@NonNull
+	protected final BluetoothGattCharacteristic characteristic(@NonNull final UUID uuid,
+														 	   final int properties, final int permissions,
+															   final BluetoothGattDescriptor... descriptors) {
+		return characteristic(uuid, properties, permissions, null, descriptors);
+	}
+
+	@NonNull
+	protected final BluetoothGattCharacteristic sharedCharacteristic(@NonNull final UUID uuid,
+																	 final int properties, final int permissions,
+																	 @Nullable final byte[] initialValue,
+																	 final BluetoothGattDescriptor... descriptors) {
+		final BluetoothGattCharacteristic characteristic = characteristic(uuid, properties, permissions, initialValue, descriptors);
+		if (sharedCharacteristics == null)
+			sharedCharacteristics = new ArrayList<>();
+		sharedCharacteristics.add(characteristic);
+		return characteristic;
+	}
+
+	@NonNull
+	protected final BluetoothGattCharacteristic sharedCharacteristic(@NonNull final UUID uuid,
+																	 final int properties, final int permissions,
+																	 final BluetoothGattDescriptor... descriptors) {
+		return characteristic(uuid, properties, permissions, null, descriptors);
+	}
+
+	@NonNull
+	protected final BluetoothGattDescriptor descriptor(@NonNull final UUID uuid, final int permissions,
+													   @Nullable final byte[] initialValue) {
+		final BluetoothGattDescriptor descriptor = new BluetoothGattDescriptor(uuid, permissions);
+		descriptor.setValue(initialValue);
+		return descriptor;
+	}
+
+	@NonNull
+	protected final BluetoothGattDescriptor descriptor(@NonNull final UUID uuid, final int permissions) {
+		return descriptor(uuid, permissions, null);
+	}
+
+	@NonNull
+	protected final BluetoothGattDescriptor sharedDescriptor(@NonNull final UUID uuid,
+															 final int permissions,
+															 @Nullable final byte[] initialValue) {
+		final BluetoothGattDescriptor descriptor = descriptor(uuid, permissions, initialValue);
+		if (sharedDescriptors == null)
+			sharedDescriptors = new ArrayList<>();
+		sharedDescriptors.add(descriptor);
+		return descriptor;
+	}
+
+	@NonNull
+	protected final BluetoothGattDescriptor sharedDescriptor(@NonNull final UUID uuid,
+															 final int permissions) {
+		return descriptor(uuid, permissions, null);
+	}
+
+	/**
+	 * This helper method returns a new instance of Client Characteristic Configuration Descriptor
+	 * (CCCD) that can be added to a server characteristic in {@link #initializeServer()}.
+	 *
+	 * @return The CCC descriptor used to enable and disable notifications or indications.
+	 */
+	@NonNull
+	protected final BluetoothGattDescriptor cccd() {
+		final BluetoothGattDescriptor cccd = descriptor(CLIENT_CHARACTERISTIC_CONFIG_DESCRIPTOR_UUID,
+				BluetoothGattDescriptor.PERMISSION_READ | BluetoothGattDescriptor.PERMISSION_WRITE);
+		cccd.setValue(new byte[] { 0, 0 }); // Notifications and indications disabled initially.
+		return cccd;
+	}
+
+	/**
+	 * This helper method returns a new instance of Client User Description Descriptor
+	 * that can be added to a server characteristic in {@link #initializeServer()}.
+	 *
+	 * @return The User Description descriptor.
+	 */
+	@NonNull
+	protected final BluetoothGattDescriptor description(@NonNull final String description) {
+		final BluetoothGattDescriptor cudd = new BluetoothGattDescriptor(CLIENT_USER_DESCRIPTION_DESCRIPTOR_UUID,
+				BluetoothGattDescriptor.PERMISSION_READ);
+		cudd.setValue(description.getBytes());
+		return cudd;
+	}
+
+	private final BluetoothGattServerCallback gattServerCallback = new BluetoothGattServerCallback() {
+
+		@Override
+		public void onServiceAdded(final int status, @NonNull final BluetoothGattService service) {
+			if (status == BluetoothGatt.GATT_SUCCESS) {
+				try {
+					final BluetoothGattService nextService = serverServices.remove();
+					server.addService(nextService);
+				} catch (final Exception e) {
+					log(Log.INFO, "[Server] All services added successfully");
+					if (userCallbacks != null)
+						userCallbacks.onServerReady();
+					serverServices = null;
+				}
+			} else {
+				log(Log.ERROR, "[Server] Adding service failed with error " + status);
+			}
+		}
+
+		@Override
+		public void onConnectionStateChange(@NonNull final BluetoothDevice device, final int status, final int newState) {
+			if (status == BluetoothGatt.GATT_SUCCESS && newState == BluetoothGatt.STATE_CONNECTED) {
+				if (userCallbacks != null)
+					userCallbacks.onDeviceConnectedToServer(device);
+			} else {
+				if (userCallbacks != null)
+					userCallbacks.onDeviceDisconnectedFromServer(device);
+			}
+		}
+
+		@Override
+		public void onCharacteristicReadRequest(@NonNull final BluetoothDevice device,
+												final int requestId, final int offset,
+												@NonNull final BluetoothGattCharacteristic characteristic) {
+			log(Log.WARN, "Click offset: " + offset);
+			final BleManagerHandler handler = getRequestHandler(device);
+			if (handler != null) {
+				handler.onCharacteristicReadRequest(server, device, requestId, offset, characteristic,
+						sharedCharacteristics != null && sharedCharacteristics.contains(characteristic));
+			}
+		}
+
+		@Override
+		public void onCharacteristicWriteRequest(@NonNull final BluetoothDevice device, final int requestId,
+												 @NonNull final BluetoothGattCharacteristic characteristic,
+												 final boolean preparedWrite, final boolean responseNeeded,
+												 final int offset, @NonNull final byte[] value) {
+			final BleManagerHandler handler = getRequestHandler(device);
+			if (handler != null) {
+				handler.onCharacteristicWriteRequest(server, device, requestId, characteristic,
+						sharedCharacteristics != null && sharedCharacteristics.contains(characteristic),
+						preparedWrite, responseNeeded, offset, value);
+			}
+		}
+
+		@Override
+		public void onDescriptorReadRequest(@NonNull final BluetoothDevice device, final int requestId, final int offset,
+											@NonNull final BluetoothGattDescriptor descriptor) {
+			final BleManagerHandler handler = getRequestHandler(device);
+			if (handler != null) {
+				handler.onDescriptorReadRequest(server, device, requestId, offset, descriptor,
+						sharedDescriptors != null && sharedDescriptors.contains(descriptor));
+			}
+		}
+
+		@Override
+		public void onDescriptorWriteRequest(@NonNull final BluetoothDevice device, final int requestId,
+											 @NonNull final BluetoothGattDescriptor descriptor,
+											 final boolean preparedWrite, final boolean responseNeeded,
+											 final int offset, @NonNull final byte[] value) {
+			final BleManagerHandler handler = getRequestHandler(device);
+			if (handler != null) {
+				handler.onDescriptorWriteRequest(server, device, requestId, descriptor,
+						sharedDescriptors != null && sharedDescriptors.contains(descriptor),
+						preparedWrite, responseNeeded, offset, value);
+			}
+		}
+
+		@Override
+		public void onExecuteWrite(@NonNull final BluetoothDevice device, final int requestId,
+								   final boolean execute) {
+			final BleManagerHandler handler = getRequestHandler(device);
+			if (handler != null) {
+				handler.onExecuteWrite(server, device, requestId, execute);
+			}
+	}
+
+		@Override
+		public void onNotificationSent(@NonNull final BluetoothDevice device, final int status) {
+			final BleManagerHandler handler = getRequestHandler(device);
+			if (handler != null) {
+				handler.onNotificationSent(server, device, status);
+			}
+		}
+
+		@Override
+		public void onMtuChanged(@NonNull final BluetoothDevice device, final int mtu) {
+			final BleManagerHandler handler = getRequestHandler(device);
+			if (handler != null) {
+				handler.onMtuChanged(server, device, mtu);
+			}
+		}
+	};
+}

--- a/ble/src/main/java/no/nordicsemi/android/ble/BleServerManager.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/BleServerManager.java
@@ -29,17 +29,17 @@ import no.nordicsemi.android.ble.utils.ILogger;
  * @since 2.2
  */
 @SuppressWarnings({"WeakerAccess", "unused"})
-public abstract class BleServerManager<E extends BleServerManagerCallbacks> implements ILogger {
-	public final static UUID CHARACTERISTIC_EXTENDED_PROPERTIES_DESCRIPTOR_UUID = UUID.fromString("00002900-0000-1000-8000-00805f9b34fb");
-	public final static UUID CLIENT_USER_DESCRIPTION_DESCRIPTOR_UUID            = UUID.fromString("00002901-0000-1000-8000-00805f9b34fb");
-	public final static UUID CLIENT_CHARACTERISTIC_CONFIG_DESCRIPTOR_UUID       = UUID.fromString("00002902-0000-1000-8000-00805f9b34fb");
+public abstract class BleServerManager implements ILogger {
+	private final static UUID CHARACTERISTIC_EXTENDED_PROPERTIES_DESCRIPTOR_UUID = UUID.fromString("00002900-0000-1000-8000-00805f9b34fb");
+	private final static UUID CLIENT_USER_DESCRIPTION_DESCRIPTOR_UUID            = UUID.fromString("00002901-0000-1000-8000-00805f9b34fb");
+	private final static UUID CLIENT_CHARACTERISTIC_CONFIG_DESCRIPTOR_UUID       = UUID.fromString("00002902-0000-1000-8000-00805f9b34fb");
 
 	/** Bluetooth GATT server instance, or null if not opened. */
 	private BluetoothGattServer server;
 
 	private final List<BleManager> managers = new ArrayList<>();
 	private final Context context;
-	private E userCallbacks;
+	private BleServerManagerCallbacks callbacks;
 
 	/**
 	 * List of server services returned by {@link #initializeServer()}.
@@ -79,8 +79,8 @@ public abstract class BleServerManager<E extends BleServerManagerCallbacks> impl
 				final BluetoothGattService service = serverServices.remove();
 				server.addService(service);
 			} catch (final NoSuchElementException e) {
-				if (userCallbacks != null)
-					userCallbacks.onServerReady();
+				if (callbacks != null)
+					callbacks.onServerReady();
 			} catch (final Exception e) {
 				close();
 				return false;
@@ -112,8 +112,8 @@ public abstract class BleServerManager<E extends BleServerManagerCallbacks> impl
 	 *
 	 * @param callbacks the callback listener.
 	 */
-	public final void setManagerCallbacks(@NonNull final E callbacks) {
-		userCallbacks = callbacks;
+	public final void setManagerCallbacks(@NonNull final BleServerManagerCallbacks callbacks) {
+		this.callbacks = callbacks;
 	}
 
 	/**
@@ -457,8 +457,8 @@ public abstract class BleServerManager<E extends BleServerManagerCallbacks> impl
 					server.addService(nextService);
 				} catch (final Exception e) {
 					log(Log.INFO, "[Server] All services added successfully");
-					if (userCallbacks != null)
-						userCallbacks.onServerReady();
+					if (callbacks != null)
+						callbacks.onServerReady();
 					serverServices = null;
 				}
 			} else {
@@ -469,11 +469,11 @@ public abstract class BleServerManager<E extends BleServerManagerCallbacks> impl
 		@Override
 		public void onConnectionStateChange(@NonNull final BluetoothDevice device, final int status, final int newState) {
 			if (status == BluetoothGatt.GATT_SUCCESS && newState == BluetoothGatt.STATE_CONNECTED) {
-				if (userCallbacks != null)
-					userCallbacks.onDeviceConnectedToServer(device);
+				if (callbacks != null)
+					callbacks.onDeviceConnectedToServer(device);
 			} else {
-				if (userCallbacks != null)
-					userCallbacks.onDeviceDisconnectedFromServer(device);
+				if (callbacks != null)
+					callbacks.onDeviceDisconnectedFromServer(device);
 			}
 		}
 

--- a/ble/src/main/java/no/nordicsemi/android/ble/BleServerManagerCallbacks.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/BleServerManagerCallbacks.java
@@ -1,0 +1,30 @@
+package no.nordicsemi.android.ble;
+
+import android.bluetooth.BluetoothDevice;
+
+import androidx.annotation.NonNull;
+
+public interface BleServerManagerCallbacks {
+
+	/**
+	 * Called when the server was started and all services have been added successfully.
+	 */
+	void onServerReady();
+
+	/**
+	 * This methods is called whenever a Bluetooth LE device connects or when was already connected
+	 * when the {@link BleServerManager} was created.
+	 *
+	 * @param device the connected device.
+	 */
+	void onDeviceConnectedToServer(@NonNull final BluetoothDevice device);
+
+	/**
+	 * Called when the device has disconnected (when the callback returned
+	 * {@link android.bluetooth.BluetoothGattServerCallback#onConnectionStateChange(BluetoothDevice, int, int)}
+	 * with state DISCONNECTED).
+	 *
+	 * @param device the device that got disconnected.
+	 */
+	void onDeviceDisconnectedFromServer(@NonNull final BluetoothDevice device);
+}

--- a/ble/src/main/java/no/nordicsemi/android/ble/Bytes.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/Bytes.java
@@ -23,6 +23,13 @@ final class Bytes {
 		return copy;
 	}
 
+	/**
+	 * Concatenates two byte arrays. The right one will be places at the given offset.
+	 * @param left the first part
+	 * @param right the second part
+	 * @param offset the offset
+	 * @return the concatenated byte array. Result will be at least offset-bytes long.
+	 */
 	static byte[] concat(@Nullable final byte[] left, @Nullable final byte[] right, @IntRange(from = 0) final int offset) {
 		final int length = offset + (right != null ? right.length : 0);
 		final byte[] result = new byte[length];

--- a/ble/src/main/java/no/nordicsemi/android/ble/Bytes.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/Bytes.java
@@ -23,4 +23,20 @@ final class Bytes {
 		return copy;
 	}
 
+
+	static byte[] concat(@Nullable final byte[] left, @Nullable final byte[] right) {
+		final int offset = left != null ? left.length : 0;
+		return concat(left, right, offset);
+	}
+
+	static byte[] concat(@Nullable final byte[] left, @Nullable final byte[] right, @IntRange(from = 0) final int offset) {
+		final int length = offset + (right != null ? right.length : 0);
+		final byte[] result = new byte[length];
+		if (left != null)
+			System.arraycopy(left, 0, result, 0, left.length);
+		if (right != null)
+			System.arraycopy(right, 0, result, offset, right.length);
+		return result;
+	}
+
 }

--- a/ble/src/main/java/no/nordicsemi/android/ble/Bytes.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/Bytes.java
@@ -23,12 +23,6 @@ final class Bytes {
 		return copy;
 	}
 
-
-	static byte[] concat(@Nullable final byte[] left, @Nullable final byte[] right) {
-		final int offset = left != null ? left.length : 0;
-		return concat(left, right, offset);
-	}
-
 	static byte[] concat(@Nullable final byte[] left, @Nullable final byte[] right, @IntRange(from = 0) final int offset) {
 		final int length = offset + (right != null ? right.length : 0);
 		final byte[] result = new byte[length];

--- a/ble/src/main/java/no/nordicsemi/android/ble/Bytes.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/Bytes.java
@@ -1,0 +1,26 @@
+package no.nordicsemi.android.ble;
+
+import androidx.annotation.IntRange;
+import androidx.annotation.Nullable;
+
+final class Bytes {
+
+	/**
+	 * Copies max length bytes of the given array, starting from offset.
+	 * @param value the data buffer.
+	 * @param offset the initial offset.
+	 * @param length maximum length/
+	 * @return The copy.
+	 */
+	static byte[] copy(@Nullable final byte[] value,
+					   @IntRange(from = 0) final int offset,
+					   @IntRange(from = 0) final int length) {
+		if (value == null || offset > value.length)
+			return null;
+		final int maxLength = Math.min(value.length - offset, length);
+		final byte[] copy = new byte[maxLength];
+		System.arraycopy(value, offset, copy, 0, maxLength);
+		return copy;
+	}
+
+}

--- a/ble/src/main/java/no/nordicsemi/android/ble/ConditionalWaitRequest.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/ConditionalWaitRequest.java
@@ -1,0 +1,98 @@
+package no.nordicsemi.android.ble;
+
+import android.os.Handler;
+import android.util.Log;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import no.nordicsemi.android.ble.callback.BeforeCallback;
+import no.nordicsemi.android.ble.callback.FailCallback;
+import no.nordicsemi.android.ble.callback.InvalidRequestCallback;
+import no.nordicsemi.android.ble.callback.SuccessCallback;
+
+@SuppressWarnings({"unused", "WeakerAccess"})
+public final class ConditionalWaitRequest<T> extends AwaitingRequest {
+
+	/**
+	 * The condition object.
+	 */
+	public interface Condition<T> {
+		boolean predicate(@Nullable final T parameter);
+	}
+
+	@NonNull
+	private final Condition<T> condition;
+	@Nullable
+	private final T parameter;
+	/** Expected value of the condition to stop waiting. */
+	private boolean expected = false;
+
+	ConditionalWaitRequest(@NonNull final Type type, @NonNull final Condition<T> condition,
+						   @Nullable final T parameter) {
+		super(type);
+		this.condition = condition;
+		this.parameter = parameter;
+	}
+
+	@NonNull
+	@Override
+	ConditionalWaitRequest<T> setRequestHandler(@NonNull final RequestHandler requestHandler) {
+		super.setRequestHandler(requestHandler);
+		return this;
+	}
+
+	@NonNull
+	@Override
+	public ConditionalWaitRequest<T> setHandler(@NonNull final Handler handler) {
+		super.setHandler(handler);
+		return this;
+	}
+
+	@Override
+	@NonNull
+	public ConditionalWaitRequest<T> done(@NonNull final SuccessCallback callback) {
+		super.done(callback);
+		return this;
+	}
+
+	@Override
+	@NonNull
+	public ConditionalWaitRequest<T> fail(@NonNull final FailCallback callback) {
+		super.fail(callback);
+		return this;
+	}
+
+	@NonNull
+	@Override
+	public ConditionalWaitRequest<T> invalid(@NonNull final InvalidRequestCallback callback) {
+		super.invalid(callback);
+		return this;
+	}
+
+	@Override
+	@NonNull
+	public ConditionalWaitRequest<T> before(@NonNull final BeforeCallback callback) {
+		super.before(callback);
+		return this;
+	}
+
+	/**
+	 * Negates the expected value of the predicate.
+	 *
+	 * @return The request.
+	 */
+	@NonNull
+	public ConditionalWaitRequest<T> negate() {
+		expected = true;
+		return this;
+	}
+
+	boolean isFulfilled() {
+		try {
+			return condition.predicate(parameter) == expected;
+		} catch (final Exception e) {
+			Log.e("ConditionalWaitRequest", "Error while checking predicate", e);
+			return true;
+		}
+	}
+}

--- a/ble/src/main/java/no/nordicsemi/android/ble/MtuRequest.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/MtuRequest.java
@@ -33,7 +33,7 @@ import no.nordicsemi.android.ble.callback.InvalidRequestCallback;
 import no.nordicsemi.android.ble.callback.MtuCallback;
 import no.nordicsemi.android.ble.callback.SuccessCallback;
 
-public final class MtuRequest extends SimpleValueRequest<MtuCallback>implements Operation {
+public final class MtuRequest extends SimpleValueRequest<MtuCallback> implements Operation {
 	private final int value;
 
 	MtuRequest(@NonNull final Type type, @IntRange(from = 23, to = 517) int mtu) {

--- a/ble/src/main/java/no/nordicsemi/android/ble/PhyRequest.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/PhyRequest.java
@@ -48,13 +48,13 @@ public final class PhyRequest extends SimpleValueRequest<PhyCallback> implements
 	 * Bluetooth LE 2M PHY mask. Used to specify LE 2M Physical Channel as one of many available
 	 * options in a bitmask.
 	 */
-	public static final int PHY_LE_2M_MASK = 2;
+	public static final int PHY_LE_2M_MASK = 1 << 1;
 
 	/**
 	 * Bluetooth LE Coded PHY mask. Used to specify LE Coded Physical Channel as one of many
 	 * available options in a bitmask.
 	 */
-	public static final int PHY_LE_CODED_MASK = 4;
+	public static final int PHY_LE_CODED_MASK = 1 << 2;
 
 	/**
 	 * No preferred coding when transmitting on the LE Coded PHY.

--- a/ble/src/main/java/no/nordicsemi/android/ble/ReadRssiRequest.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/ReadRssiRequest.java
@@ -33,7 +33,7 @@ import no.nordicsemi.android.ble.callback.InvalidRequestCallback;
 import no.nordicsemi.android.ble.callback.RssiCallback;
 import no.nordicsemi.android.ble.callback.SuccessCallback;
 
-public final class ReadRssiRequest extends SimpleValueRequest<RssiCallback> implements Operation {
+public final class ReadRssiRequest extends SimpleValueRequest<RssiCallback> {
 
 	ReadRssiRequest(@NonNull final Type type) {
 		super(type);

--- a/ble/src/main/java/no/nordicsemi/android/ble/Request.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/Request.java
@@ -61,6 +61,8 @@ public abstract class Request {
 		CREATE_BOND,
 		REMOVE_BOND,
 		WRITE,
+		NOTIFY,
+		INDICATE,
 		READ,
 		WRITE_DESCRIPTOR,
 		READ_DESCRIPTOR,
@@ -73,6 +75,10 @@ public abstract class Request {
 		DISABLE_INDICATIONS,
 		WAIT_FOR_NOTIFICATION,
 		WAIT_FOR_INDICATION,
+		WAIT_FOR_READ,
+		WAIT_FOR_WRITE,
+		SET_VALUE,
+		SET_DESCRIPTOR_VALUE,
 		@Deprecated
 		READ_BATTERY_LEVEL,
 		@Deprecated
@@ -433,6 +439,82 @@ public abstract class Request {
 	}
 
 	/**
+	 * Creates new Send Notification request. The request will not be executed if given
+	 * characteristic is null or does not have NOTIFY property.
+	 * After the operation is complete a proper callback will be invoked.
+	 *
+	 * @param characteristic characteristic to be notified.
+	 * @param value          value to be sent. The array is copied into another buffer so it's
+	 *                       safe to reuse the array again.
+	 * @return The new request.
+	 */
+	@NonNull
+	static WriteRequest newNotificationRequest(
+			@Nullable final BluetoothGattCharacteristic characteristic,
+			@Nullable final byte[] value) {
+		return new WriteRequest(Type.NOTIFY, characteristic, value, 0,
+				value != null ? value.length : 0);
+	}
+
+	/**
+	 * Creates new Send Notification request. The request will not be executed if given
+	 * characteristic is null or does not have NOTIFY property.
+	 * After the operation is complete a proper callback will be invoked.
+	 *
+	 * @param characteristic characteristic to be notified.
+	 * @param value          value to be sent. The array is copied into another buffer so it's
+	 *                       safe to reuse the array again.
+	 * @param offset         the offset from which value has to be copied.
+	 * @param length         number of bytes to be copied from the value buffer.
+	 * @return The new request.
+	 */
+	@NonNull
+	static WriteRequest newNotificationRequest(
+			@Nullable final BluetoothGattCharacteristic characteristic,
+			@Nullable final byte[] value,
+			@IntRange(from = 0) final int offset, @IntRange(from = 0) final int length) {
+		return new WriteRequest(Type.NOTIFY, characteristic, value, offset, length);
+	}
+
+	/**
+	 * Creates new Send Indication request. The request will not be executed if given
+	 * characteristic is null or does not have INDICATE property.
+	 * After the operation is complete a proper callback will be invoked.
+	 *
+	 * @param characteristic characteristic to be indicated.
+	 * @param value          value to be sent. The array is copied into another buffer so it's
+	 *                       safe to reuse the array again.
+	 * @return The new request.
+	 */
+	@NonNull
+	static WriteRequest newIndicationRequest(
+			@Nullable final BluetoothGattCharacteristic characteristic,
+			@Nullable final byte[] value) {
+		return new WriteRequest(Type.INDICATE, characteristic, value, 0,
+				value != null ? value.length : 0);
+	}
+
+	/**
+	 * Creates new Send Indication request. The request will not be executed if given
+	 * characteristic is null or does not have INDICATE property.
+	 * After the operation is complete a proper callback will be invoked.
+	 *
+	 * @param characteristic characteristic to be indicated.
+	 * @param value          value to be sent. The array is copied into another buffer so it's
+	 *                       safe to reuse the array again.
+	 * @param offset         the offset from which value has to be copied.
+	 * @param length         number of bytes to be copied from the value buffer.
+	 * @return The new request.
+	 */
+	@NonNull
+	static WriteRequest newIndicationRequest(
+			@Nullable final BluetoothGattCharacteristic characteristic,
+			@Nullable final byte[] value,
+			@IntRange(from = 0) final int offset, @IntRange(from = 0) final int length) {
+		return new WriteRequest(Type.INDICATE, characteristic, value, offset, length);
+	}
+
+	/**
 	 * Creates new Enable Notification request. The request will not be executed if given
 	 * characteristic is null, does not have NOTIFY property or the CCCD.
 	 * After the operation is complete a proper callback will be invoked.
@@ -538,6 +620,209 @@ public abstract class Request {
 	public static WaitForValueChangedRequest newWaitForIndicationRequest(
 			@Nullable final BluetoothGattCharacteristic characteristic) {
 		return new WaitForValueChangedRequest(Type.WAIT_FOR_INDICATION, characteristic);
+	}
+
+	/**
+	 * Creates new Wait For Write request. The request will not be executed if given
+	 * characteristic is null, or does not have WRITE property.
+	 * After the operation is complete a proper callback will be invoked.
+	 * <p>
+	 * If the write should be triggered by another operation (for example writing an
+	 * op code), set it with {@link WaitForValueChangedRequest#trigger(Operation)}.
+	 *
+	 * @param characteristic characteristic that should be written by the remote device.
+	 * @return The new request.
+	 */
+	@NonNull
+	static WaitForValueChangedRequest newWaitForWriteRequest(
+			@Nullable final BluetoothGattCharacteristic characteristic) {
+		return new WaitForValueChangedRequest(Type.WAIT_FOR_WRITE, characteristic);
+	}
+
+	/**
+	 * Creates new Wait For Read request. The request will not be executed if given server
+	 * characteristic is null, or does not have READ property.
+	 * After the operation is complete a proper callback will be invoked.
+	 * <p>
+	 * If the read should be triggered by another operation (for example writing an
+	 * op code), set it with {@link WaitForValueChangedRequest#trigger(Operation)}.
+	 *
+	 * @param characteristic characteristic that should be read by the remote device.
+	 * @return The new request.
+	 */
+	@NonNull
+	static WaitForReadRequest newWaitForReadRequest(
+			@Nullable final BluetoothGattCharacteristic characteristic) {
+		return new WaitForReadRequest(Type.WAIT_FOR_READ, characteristic);
+	}
+
+	/**
+	 * Creates new Wait For Read request. The request will not be executed if given server
+	 * characteristic is null, or does not have READ property.
+	 * After the operation is complete a proper callback will be invoked.
+	 * <p>
+	 * If the read should be triggered by another operation (for example writing an
+	 * op code), set it with {@link WaitForValueChangedRequest#trigger(Operation)}.
+	 *
+	 * @param characteristic characteristic that should be read by the remote device.
+	 * @param value          value to be sent. The array is copied into another buffer so it's
+	 *                       safe to reuse the array again.
+	 * @return The new request.
+	 */
+	@NonNull
+	static WaitForReadRequest newWaitForReadRequest(
+			@Nullable final BluetoothGattCharacteristic characteristic,
+			@Nullable final byte[] value) {
+		return new WaitForReadRequest(Type.WAIT_FOR_READ, characteristic, value, 0,
+				value != null ? value.length : 0);
+	}
+
+	/**
+	 * Creates new Wait For Read request. The request will not be executed if given server
+	 * characteristic is null, or does not have READ property.
+	 * After the operation is complete a proper callback will be invoked.
+	 * <p>
+	 * If the read should be triggered by another operation (for example writing an
+	 * op code), set it with {@link WaitForValueChangedRequest#trigger(Operation)}.
+	 *
+	 * @param characteristic characteristic that should be read by the remote device.
+	 * @param value          value to be sent. The array is copied into another buffer so it's
+	 *                       safe to reuse the array again.
+	 * @param offset         the offset from which value has to be copied.
+	 * @param length         number of bytes to be copied from the value buffer.
+	 * @return The new request.
+	 */
+	@NonNull
+	static WaitForReadRequest newWaitForReadRequest(
+			@Nullable final BluetoothGattCharacteristic characteristic,
+			@Nullable final byte[] value,
+			@IntRange(from = 0) final int offset, @IntRange(from = 0) final int length) {
+		return new WaitForReadRequest(Type.WAIT_FOR_READ, characteristic, value, offset, length);
+	}
+
+	/**
+	 * Creates new Wait For Read request. The request will not be executed if given server
+	 * characteristic is null, or does not have READ property.
+	 * After the operation is complete a proper callback will be invoked.
+	 * <p>
+	 * If the read should be triggered by another operation (for example writing an
+	 * op code), set it with {@link WaitForValueChangedRequest#trigger(Operation)}.
+	 *
+	 * @param descriptor descriptor that should be read by the remote device.
+	 * @return The new request.
+	 */
+	@NonNull
+	static WaitForReadRequest newWaitForReadRequest(
+			@Nullable final BluetoothGattDescriptor descriptor) {
+		return new WaitForReadRequest(Type.WAIT_FOR_READ, descriptor);
+	}
+
+	/**
+	 * Creates new Wait For Read request. The request will not be executed if given server
+	 * characteristic is null, or does not have READ property.
+	 * After the operation is complete a proper callback will be invoked.
+	 * <p>
+	 * If the read should be triggered by another operation (for example writing an
+	 * op code), set it with {@link WaitForValueChangedRequest#trigger(Operation)}.
+	 *
+	 * @param descriptor descriptor that should be read by the remote device.
+	 * @param value      value to be sent. The array is copied into another buffer so it's
+	 *                   safe to reuse the array again.
+	 * @return The new request.
+	 */
+	@NonNull
+	static WaitForReadRequest newWaitForReadRequest(
+			@Nullable final BluetoothGattDescriptor descriptor,
+			@Nullable final byte[] value) {
+		return new WaitForReadRequest(Type.WAIT_FOR_READ, descriptor, value, 0,
+				value != null ? value.length : 0);
+	}
+
+	/**
+	 * Creates new Wait For Read request. The request will not be executed if given server
+	 * characteristic is null, or does not have READ property.
+	 * After the operation is complete a proper callback will be invoked.
+	 * <p>
+	 * If the read should be triggered by another operation (for example writing an
+	 * op code), set it with {@link WaitForValueChangedRequest#trigger(Operation)}.
+	 *
+	 * @param descriptor descriptor that should be read by the remote device.
+	 * @param value      value to be sent. The array is copied into another buffer so it's
+	 *                   safe to reuse the array again.
+	 * @param offset     the offset from which value has to be copied.
+	 * @param length     number of bytes to be copied from the value buffer.
+	 * @return The new request.
+	 */
+	@NonNull
+	static WaitForReadRequest newWaitForReadRequest(
+			@Nullable final BluetoothGattDescriptor descriptor,
+			@Nullable final byte[] value,
+			@IntRange(from = 0) final int offset, @IntRange(from = 0) final int length) {
+		return new WaitForReadRequest(Type.WAIT_FOR_READ, descriptor, value, offset, length);
+	}
+
+	/**
+	 * Creates new Set Characteristic Value request.
+	 *
+	 * @param characteristic the target characteristic for value set.
+	 * @param value          the new data to be assigned.
+	 * @return The new request.
+	 */
+	@NonNull
+	static SetValueRequest newSetValueRequest(
+			@Nullable final BluetoothGattCharacteristic characteristic,
+			@Nullable final byte[] value) {
+		return new SetValueRequest(Type.SET_VALUE, characteristic, value, 0,
+				value != null ? value.length : 0);
+	}
+
+	/**
+	 * Creates new Set Characteristic Value request.
+	 *
+	 * @param characteristic the target characteristic for value set.
+	 * @param value          the new data to be assigned.
+	 * @param offset         the offset from which value has to be copied.
+	 * @param length         number of bytes to be copied from the value buffer.
+	 * @return The new request.
+	 */
+	@NonNull
+	static SetValueRequest newSetValueRequest(
+			@Nullable final BluetoothGattCharacteristic characteristic,
+			@Nullable final byte[] value,
+			@IntRange(from = 0) final int offset, @IntRange(from = 0) final int length) {
+		return new SetValueRequest(Type.SET_VALUE, characteristic, value, offset, length);
+	}
+
+	/**
+	 * Creates new Set Descriptor Value request.
+	 *
+	 * @param descriptor the target descriptor for value set.
+	 * @param value      the new data to be assigned.
+	 * @return The new request.
+	 */
+	@NonNull
+	static SetValueRequest newSetValueRequest(
+			@Nullable final BluetoothGattDescriptor descriptor,
+			@Nullable final byte[] value) {
+		return new SetValueRequest(Type.SET_DESCRIPTOR_VALUE, descriptor, value, 0,
+				value != null ? value.length : 0);
+	}
+
+	/**
+	 * Creates new Set Descriptor Value request.
+	 *
+	 * @param descriptor the target descriptor for value set.
+	 * @param value      the new data to be assigned.
+	 * @param offset     the offset from which value has to be copied.
+	 * @param length     number of bytes to be copied from the value buffer.
+	 * @return The new request.
+	 */
+	@NonNull
+	static SetValueRequest newSetValueRequest(
+			@Nullable final BluetoothGattDescriptor descriptor,
+			@Nullable final byte[] value,
+			@IntRange(from = 0) final int offset, @IntRange(from = 0) final int length) {
+		return new SetValueRequest(Type.SET_VALUE, descriptor, value, offset, length);
 	}
 
 	/**

--- a/ble/src/main/java/no/nordicsemi/android/ble/Request.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/Request.java
@@ -77,6 +77,7 @@ public abstract class Request {
 		WAIT_FOR_INDICATION,
 		WAIT_FOR_READ,
 		WAIT_FOR_WRITE,
+		WAIT_FOR_CONDITION,
 		SET_VALUE,
 		SET_DESCRIPTOR_VALUE,
 		@Deprecated
@@ -775,6 +776,19 @@ public abstract class Request {
 			@Nullable final byte[] value,
 			@IntRange(from = 0) final int offset, @IntRange(from = 0) final int length) {
 		return new WaitForReadRequest(Type.WAIT_FOR_READ, descriptor, value, offset, length);
+	}
+
+	/**
+	 * Creates new Conditional Wait Request. The request will wait until the condition is fulfilled.
+	 *
+	 * @param condition the condition to check.
+	 * @param parameter an optional parameter.
+	 * @return The new request.
+	 */
+	@NonNull
+	static <T> ConditionalWaitRequest<T> newConditionalWaitRequest(@NonNull final ConditionalWaitRequest.Condition<T> condition,
+																   @Nullable final T parameter) {
+		return new ConditionalWaitRequest<>(Type.WAIT_FOR_CONDITION, condition, parameter);
 	}
 
 	/**

--- a/ble/src/main/java/no/nordicsemi/android/ble/SetValueRequest.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/SetValueRequest.java
@@ -12,7 +12,7 @@ import no.nordicsemi.android.ble.callback.FailCallback;
 import no.nordicsemi.android.ble.callback.InvalidRequestCallback;
 import no.nordicsemi.android.ble.callback.SuccessCallback;
 
-@SuppressWarnings({"WeakerAccess", "unused"})
+@SuppressWarnings({"unused", "WeakerAccess"})
 public final class SetValueRequest extends SimpleRequest {
 	private final byte[] data;
 	private boolean longReadSupported = true;

--- a/ble/src/main/java/no/nordicsemi/android/ble/SetValueRequest.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/SetValueRequest.java
@@ -1,0 +1,108 @@
+package no.nordicsemi.android.ble;
+
+import android.bluetooth.BluetoothGattCharacteristic;
+import android.bluetooth.BluetoothGattDescriptor;
+import android.os.Handler;
+
+import androidx.annotation.IntRange;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import no.nordicsemi.android.ble.callback.BeforeCallback;
+import no.nordicsemi.android.ble.callback.FailCallback;
+import no.nordicsemi.android.ble.callback.InvalidRequestCallback;
+import no.nordicsemi.android.ble.callback.SuccessCallback;
+
+@SuppressWarnings({"WeakerAccess", "unused"})
+public final class SetValueRequest extends SimpleRequest {
+	private final byte[] data;
+	private boolean longReadSupported = true;
+
+	SetValueRequest(@NonNull final Type type, @Nullable final BluetoothGattCharacteristic characteristic,
+					@Nullable final byte[] data,
+					@IntRange(from = 0) final int offset, @IntRange(from = 0) final int length) {
+		super(type, characteristic);
+		this.data = Bytes.copy(data, offset, length);
+	}
+
+	SetValueRequest(@NonNull final Type type, @Nullable final BluetoothGattDescriptor descriptor,
+					@Nullable final byte[] data,
+					@IntRange(from = 0) final int offset, @IntRange(from = 0) final int length) {
+		super(type, descriptor);
+		this.data = Bytes.copy(data, offset, length);
+	}
+
+	@NonNull
+	@Override
+	SetValueRequest setRequestHandler(@NonNull final RequestHandler requestHandler) {
+		super.setRequestHandler(requestHandler);
+		return this;
+	}
+
+	@NonNull
+	@Override
+	public SetValueRequest setHandler(@NonNull final Handler handler) {
+		super.setHandler(handler);
+		return this;
+	}
+
+	@Override
+	@NonNull
+	public SetValueRequest done(@NonNull final SuccessCallback callback) {
+		super.done(callback);
+		return this;
+	}
+
+	@Override
+	@NonNull
+	public SetValueRequest fail(@NonNull final FailCallback callback) {
+		super.fail(callback);
+		return this;
+	}
+
+	@NonNull
+	@Override
+	public SetValueRequest invalid(@NonNull final InvalidRequestCallback callback) {
+		super.invalid(callback);
+		return this;
+	}
+
+	@Override
+	@NonNull
+	public SetValueRequest before(@NonNull final BeforeCallback callback) {
+		super.before(callback);
+		return this;
+	}
+
+	/**
+	 * Sets whether Long Read procedure is supported by the remote device on the given characteristic
+	 * or descriptor. If set to false, the given data will be truncated to match MTU.
+	 * Otherwise (default) will only be truncated to fit in the maximum Long Read length, that is
+	 * 512 bytes.
+	 *
+	 * @param longReadSupported whether Long Read procedure is supported on the remote device on
+	 *                          the given characteristic or descriptor.
+	 * @return The request.
+	 */
+	@NonNull
+	public SetValueRequest allowLongRead(final boolean longReadSupported) {
+		this.longReadSupported = longReadSupported;
+		return this;
+	}
+
+	/**
+	 * Returns the data to be assigned to characteristic or descriptor.
+	 * If {@link #allowLongRead(boolean)} was called with parameter set to false, the data set will
+	 * be truncated to match the MTU. Otherwise, they will be truncated to match the maximum
+	 * length of Long-Read procedure, that is 512 bytes.
+	 * See Bluetooth Core Specification version 5.1 | Vol 3, Part F, 3.2.9 Long Attribute Values.
+	 *
+	 * @param mtu the current MTU.
+	 * @return The data to be set to the given characteristic or descriptor.
+	 */
+	byte[] getData(@IntRange(from = 23, to = 517) final int mtu) {
+		final int maxLength = longReadSupported ? 512 : mtu - 3;
+		if (data.length < maxLength)
+			return data;
+		return Bytes.copy(data, 0, maxLength);
+	}
+}

--- a/ble/src/main/java/no/nordicsemi/android/ble/SimpleRequest.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/SimpleRequest.java
@@ -39,7 +39,6 @@ import no.nordicsemi.android.ble.exception.RequestFailedException;
  * A request that requires a {@link android.bluetooth.BluetoothGattCallback callback} or can't
  * have timeout for any other reason. This class defines the {@link #await()} method.
  */
-@SuppressWarnings({"WeakerAccess", "unused"})
 public class SimpleRequest extends Request {
 
 	SimpleRequest(@NonNull final Type type) {

--- a/ble/src/main/java/no/nordicsemi/android/ble/SimpleValueRequest.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/SimpleValueRequest.java
@@ -38,7 +38,6 @@ import no.nordicsemi.android.ble.exception.RequestFailedException;
  * A value request that requires a {@link android.bluetooth.BluetoothGattCallback callback} or
  * can't have timeout for any other reason. This class defines the {@link #await()} methods.
  */
-@SuppressWarnings({"WeakerAccess", "unused"})
 public abstract class SimpleValueRequest<T> extends SimpleRequest {
 	T valueCallback;
 

--- a/ble/src/main/java/no/nordicsemi/android/ble/SleepRequest.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/SleepRequest.java
@@ -31,9 +31,8 @@ import no.nordicsemi.android.ble.callback.FailCallback;
 import no.nordicsemi.android.ble.callback.InvalidRequestCallback;
 import no.nordicsemi.android.ble.callback.SuccessCallback;
 
-@SuppressWarnings({"unused"})
 public final class SleepRequest extends SimpleRequest implements Operation {
-	private long delay;
+	private final long delay;
 
 	SleepRequest(@NonNull final Type type, @IntRange(from = 0) final long delay) {
 		super(type);

--- a/ble/src/main/java/no/nordicsemi/android/ble/SleepRequest.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/SleepRequest.java
@@ -31,7 +31,7 @@ import no.nordicsemi.android.ble.callback.FailCallback;
 import no.nordicsemi.android.ble.callback.InvalidRequestCallback;
 import no.nordicsemi.android.ble.callback.SuccessCallback;
 
-public final class SleepRequest extends SimpleRequest implements Operation {
+public final class SleepRequest extends SimpleRequest {
 	private final long delay;
 
 	SleepRequest(@NonNull final Type type, @IntRange(from = 0) final long delay) {

--- a/ble/src/main/java/no/nordicsemi/android/ble/TimeoutableRequest.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/TimeoutableRequest.java
@@ -16,7 +16,6 @@ import no.nordicsemi.android.ble.exception.DeviceDisconnectedException;
 import no.nordicsemi.android.ble.exception.InvalidRequestException;
 import no.nordicsemi.android.ble.exception.RequestFailedException;
 
-@SuppressWarnings("WeakerAccess")
 public abstract class TimeoutableRequest extends Request {
 	private Runnable timeoutCallback;
 	protected long timeout;

--- a/ble/src/main/java/no/nordicsemi/android/ble/TimeoutableValueRequest.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/TimeoutableValueRequest.java
@@ -39,7 +39,7 @@ import no.nordicsemi.android.ble.exception.RequestFailedException;
  * A value request that requires a {@link android.bluetooth.BluetoothGattCallback callback} or
  * can't have timeout for any other reason. This class defines the {@link #await()} methods.
  */
-@SuppressWarnings({"WeakerAccess", "unused"})
+@SuppressWarnings({"unused"})
 public abstract class TimeoutableValueRequest<T> extends TimeoutableRequest {
 	T valueCallback;
 

--- a/ble/src/main/java/no/nordicsemi/android/ble/ValueChangedCallback.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/ValueChangedCallback.java
@@ -34,7 +34,7 @@ import no.nordicsemi.android.ble.data.DataFilter;
 import no.nordicsemi.android.ble.data.DataMerger;
 import no.nordicsemi.android.ble.data.DataStream;
 
-@SuppressWarnings({"unused", "WeakerAccess", "UnusedReturnValue"})
+@SuppressWarnings({"unused", "UnusedReturnValue"})
 public class ValueChangedCallback {
 	private ReadProgressCallback progressCallback;
 	private DataReceivedCallback valueCallback;

--- a/ble/src/main/java/no/nordicsemi/android/ble/WaitForReadRequest.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/WaitForReadRequest.java
@@ -5,8 +5,6 @@ import android.bluetooth.BluetoothGattCharacteristic;
 import android.bluetooth.BluetoothGattDescriptor;
 import android.os.Handler;
 
-import java.util.Arrays;
-
 import androidx.annotation.IntRange;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -27,7 +25,6 @@ public final class WaitForReadRequest extends AwaitingRequest<DataSentCallback> 
 	private WriteProgressCallback progressCallback;
 	private DataSplitter dataSplitter;
 	private byte[] data;
-	private byte[] currentChunk;
 	private byte[] nextChunk;
 	private int count = 0;
 	private boolean complete = false;
@@ -195,7 +192,7 @@ public final class WaitForReadRequest extends AwaitingRequest<DataSentCallback> 
 	byte[] getData(@IntRange(from = 23, to = 517) final int mtu) {
 		if (dataSplitter == null || data == null) {
 			complete = true;
-			return currentChunk = data;
+			return data;
 		}
 
 		// Read [procedure requires 3 bytes for handler and op code.
@@ -214,7 +211,7 @@ public final class WaitForReadRequest extends AwaitingRequest<DataSentCallback> 
 		if (nextChunk == null) {
 			complete = true;
 		}
-		return currentChunk = chunk;
+		return chunk;
 	}
 
 	/**
@@ -249,6 +246,7 @@ public final class WaitForReadRequest extends AwaitingRequest<DataSentCallback> 
 	 *
 	 * @return True if not all data were sent, false if the request is complete.
 	 */
+	@SuppressWarnings("BooleanMethodIsAlwaysInverted")
 	boolean hasMore() {
 		return !complete;
 	}

--- a/ble/src/main/java/no/nordicsemi/android/ble/WaitForReadRequest.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/WaitForReadRequest.java
@@ -19,7 +19,7 @@ import no.nordicsemi.android.ble.data.DataSplitter;
 import no.nordicsemi.android.ble.data.DefaultMtuSplitter;
 
 @SuppressWarnings({"unused", "WeakerAccess"})
-public final class WaitForReadRequest extends AwaitingRequest<DataSentCallback> implements Operation {
+public final class WaitForReadRequest extends AwaitingRequest<DataSentCallback> {
 	private static final DataSplitter MTU_SPLITTER = new DefaultMtuSplitter();
 
 	private WriteProgressCallback progressCallback;

--- a/ble/src/main/java/no/nordicsemi/android/ble/WaitForReadRequest.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/WaitForReadRequest.java
@@ -1,0 +1,250 @@
+package no.nordicsemi.android.ble;
+
+import android.bluetooth.BluetoothDevice;
+import android.bluetooth.BluetoothGattCharacteristic;
+import android.bluetooth.BluetoothGattDescriptor;
+import android.os.Handler;
+
+import java.util.Arrays;
+
+import androidx.annotation.IntRange;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import no.nordicsemi.android.ble.callback.BeforeCallback;
+import no.nordicsemi.android.ble.callback.DataSentCallback;
+import no.nordicsemi.android.ble.callback.FailCallback;
+import no.nordicsemi.android.ble.callback.InvalidRequestCallback;
+import no.nordicsemi.android.ble.callback.SuccessCallback;
+import no.nordicsemi.android.ble.callback.WriteProgressCallback;
+import no.nordicsemi.android.ble.data.Data;
+import no.nordicsemi.android.ble.data.DataSplitter;
+import no.nordicsemi.android.ble.data.DefaultMtuSplitter;
+
+@SuppressWarnings({"unused", "WeakerAccess"})
+public final class WaitForReadRequest extends AwaitingRequest<DataSentCallback> implements Operation {
+	private static final DataSplitter MTU_SPLITTER = new DefaultMtuSplitter();
+
+	private WriteProgressCallback progressCallback;
+	private DataSplitter dataSplitter;
+	private final byte[] data;
+	private byte[] currentChunk;
+	private byte[] nextChunk;
+	private int count = 0;
+	private boolean complete = false;
+
+	WaitForReadRequest(@NonNull final Request.Type type, @Nullable final BluetoothGattCharacteristic characteristic) {
+		super(type, characteristic);
+		// not used:
+		this.data = null;
+		// data might have been set earlier using SetValueRequest.
+		this.complete = true;
+	}
+
+	WaitForReadRequest(@NonNull final Request.Type type, @Nullable final BluetoothGattDescriptor descriptor) {
+		super(type, descriptor);
+		// not used:
+		this.data = null;
+		// data might have been set earlier using SetValueRequest.
+		this.complete = true;
+	}
+
+	WaitForReadRequest(@NonNull final Request.Type type, @Nullable final BluetoothGattCharacteristic characteristic,
+					   @Nullable final byte[] data,
+					   @IntRange(from = 0) final int offset, @IntRange(from = 0) final int length) {
+		super(type, characteristic);
+		this.data = Bytes.copy(data, offset, length);
+	}
+
+	WaitForReadRequest(@NonNull final Request.Type type, @Nullable final BluetoothGattDescriptor descriptor,
+					   @Nullable final byte[] data,
+					   @IntRange(from = 0) final int offset, @IntRange(from = 0) final int length) {
+		super(type, descriptor);
+		this.data = Bytes.copy(data, offset, length);
+	}
+
+	@NonNull
+	@Override
+	WaitForReadRequest setRequestHandler(@NonNull final RequestHandler requestHandler) {
+		super.setRequestHandler(requestHandler);
+		return this;
+	}
+
+	@NonNull
+	@Override
+	public WaitForReadRequest setHandler(@NonNull final Handler handler) {
+		super.setHandler(handler);
+		return this;
+	}
+
+	@Override
+	@NonNull
+	public WaitForReadRequest done(@NonNull final SuccessCallback callback) {
+		super.done(callback);
+		return this;
+	}
+
+	@Override
+	@NonNull
+	public WaitForReadRequest fail(@NonNull final FailCallback callback) {
+		super.fail(callback);
+		return this;
+	}
+
+	@NonNull
+	@Override
+	public WaitForReadRequest invalid(@NonNull final InvalidRequestCallback callback) {
+		super.invalid(callback);
+		return this;
+	}
+
+	@Override
+	@NonNull
+	public WaitForReadRequest before(@NonNull final BeforeCallback callback) {
+		super.before(callback);
+		return this;
+	}
+
+	@Override
+	@NonNull
+	public WaitForReadRequest with(@NonNull final DataSentCallback callback) {
+		super.with(callback);
+		return this;
+	}
+
+	@NonNull
+	public WaitForReadRequest trigger(@NonNull final Operation trigger) {
+		super.trigger(trigger);
+		return this;
+	}
+
+	/**
+	 * Adds a splitter that will be used to cut given data into multiple packets.
+	 * The splitter may modify each packet if necessary, i.e. add a flag indicating first packet,
+	 * continuation or the last packet.
+	 *
+	 * @param splitter an implementation of a splitter.
+	 * @return The request.
+	 * @see #split()
+	 */
+	@NonNull
+	public WaitForReadRequest split(@NonNull final DataSplitter splitter) {
+		this.dataSplitter = splitter;
+		this.progressCallback = null;
+		return this;
+	}
+
+	/**
+	 * Adds a splitter that will be used to cut given data into multiple packets.
+	 * The splitter may modify each packet if necessary, i.e. add a flag indicating first packet,
+	 * continuation or the last packet.
+	 *
+	 * @param splitter an implementation of a splitter.
+	 * @param callback the progress callback that will be notified each time a packet was sent.
+	 * @return The request.
+	 * @see #split()
+	 */
+	@NonNull
+	public WaitForReadRequest split(@NonNull final DataSplitter splitter,
+							  		@NonNull final WriteProgressCallback callback) {
+		this.dataSplitter = splitter;
+		this.progressCallback = callback;
+		return this;
+	}
+
+	/**
+	 * Adds a default MTU splitter that will be used to cut given data into at-most MTU-3
+	 * bytes long packets.
+	 *
+	 * @return The request.
+	 */
+	@NonNull
+	public WaitForReadRequest split() {
+		this.dataSplitter = MTU_SPLITTER;
+		this.progressCallback = null;
+		return this;
+	}
+
+	/**
+	 * Adds a default MTU splitter that will be used to cut given data into at-most MTU-3
+	 * bytes long packets.
+	 *
+	 * @param callback the progress callback that will be notified each time a packet was sent.
+	 * @return The request.
+	 */
+	@NonNull
+	public WaitForReadRequest split(@NonNull final WriteProgressCallback callback) {
+		this.dataSplitter = MTU_SPLITTER;
+		this.progressCallback = callback;
+		return this;
+	}
+
+	/**
+	 * Returns the next chunk to be sent. If data splitter was not set the date returned may
+	 * be longer than MTU. Android will try to send them using Long Write sub-procedure if
+	 * write type is {@link BluetoothGattCharacteristic#WRITE_TYPE_DEFAULT}. Other write types
+	 * will cause the data to be truncated.
+	 *
+	 * @param mtu the current MTU.
+	 * @return The next bytes to be sent.
+	 */
+	byte[] getData(@IntRange(from = 23, to = 517) final int mtu) {
+		if (dataSplitter == null || data == null) {
+			complete = true;
+			return currentChunk = data;
+		}
+
+		// Read [procedure requires 3 bytes for handler and op code.
+		final int maxLength = mtu - 3;
+
+		byte[] chunk = nextChunk;
+		// Get the first chunk.
+		if (chunk == null) {
+			chunk = dataSplitter.chunk(data, count, maxLength);
+		}
+		// If there's something to send, check if there are any more packets to be sent later.
+		if (chunk != null) {
+			nextChunk = dataSplitter.chunk(data, count + 1, maxLength);
+		}
+		// If there's no next packet left, we are done.
+		if (nextChunk == null) {
+			complete = true;
+		}
+		return currentChunk = chunk;
+	}
+
+	/**
+	 * Method called when packet has been read by the remote device.
+	 *
+	 * @param device the target device.
+	 * @param data   the data sent in {@link android.bluetooth.BluetoothGattServer#sendResponse(BluetoothDevice, int, int, int, byte[])}
+	 *               from
+	 *               {@link android.bluetooth.BluetoothGattServerCallback#onCharacteristicReadRequest(BluetoothDevice, int, int, BluetoothGattCharacteristic)}
+	 *               or
+	 *               {@link android.bluetooth.BluetoothGattServerCallback#onDescriptorReadRequest(BluetoothDevice, int, int, BluetoothGattDescriptor)}
+	 */
+	void notifyPacketRead(@NonNull final BluetoothDevice device, @Nullable final byte[] data) {
+		handler.post(() -> {
+			if (progressCallback != null)
+				progressCallback.onPacketSent(device, data, count);
+		});
+		count++;
+	}
+
+	@Override
+	void notifySuccess(@NonNull final BluetoothDevice device) {
+		handler.post(() -> {
+			if (valueCallback != null)
+				valueCallback.onDataSent(device, new Data(data));
+		});
+		super.notifySuccess(device);
+	}
+
+	/**
+	 * Returns whether there are more bytes to be sent.
+	 *
+	 * @return True if not all data were sent, false if the request is complete.
+	 */
+	boolean hasMore() {
+		return !complete;
+	}
+}

--- a/ble/src/main/java/no/nordicsemi/android/ble/WaitForReadRequest.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/WaitForReadRequest.java
@@ -26,7 +26,7 @@ public final class WaitForReadRequest extends AwaitingRequest<DataSentCallback> 
 
 	private WriteProgressCallback progressCallback;
 	private DataSplitter dataSplitter;
-	private final byte[] data;
+	private byte[] data;
 	private byte[] currentChunk;
 	private byte[] nextChunk;
 	private int count = 0;
@@ -60,6 +60,11 @@ public final class WaitForReadRequest extends AwaitingRequest<DataSentCallback> 
 					   @IntRange(from = 0) final int offset, @IntRange(from = 0) final int length) {
 		super(type, descriptor);
 		this.data = Bytes.copy(data, offset, length);
+	}
+
+	void setDataIfNull(@Nullable final byte[] data) {
+		if (this.data == null)
+			this.data = data;
 	}
 
 	@NonNull

--- a/ble/src/main/java/no/nordicsemi/android/ble/WaitForValueChangedRequest.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/WaitForValueChangedRequest.java
@@ -48,8 +48,7 @@ import no.nordicsemi.android.ble.exception.InvalidRequestException;
 import no.nordicsemi.android.ble.exception.RequestFailedException;
 
 @SuppressWarnings({"unused", "WeakerAccess"})
-public final class WaitForValueChangedRequest extends AwaitingRequest<DataReceivedCallback>
-		implements Operation {
+public final class WaitForValueChangedRequest extends AwaitingRequest<DataReceivedCallback> {
 	private ReadProgressCallback progressCallback;
 	private DataMerger dataMerger;
 	private DataStream buffer;

--- a/ble/src/main/java/no/nordicsemi/android/ble/WaitForValueChangedRequest.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/WaitForValueChangedRequest.java
@@ -24,6 +24,7 @@ package no.nordicsemi.android.ble;
 
 import android.bluetooth.BluetoothDevice;
 import android.bluetooth.BluetoothGattCharacteristic;
+import android.bluetooth.BluetoothGattDescriptor;
 import android.os.Handler;
 
 import androidx.annotation.IntRange;
@@ -60,6 +61,11 @@ public final class WaitForValueChangedRequest extends AwaitingRequest<DataReceiv
 	WaitForValueChangedRequest(@NonNull final Type type,
 							   @Nullable final BluetoothGattCharacteristic characteristic) {
 		super(type, characteristic);
+	}
+
+	WaitForValueChangedRequest(@NonNull final Type type,
+							   @Nullable final BluetoothGattDescriptor descriptor) {
+		super(type, descriptor);
 	}
 
 	@NonNull
@@ -336,6 +342,7 @@ public final class WaitForValueChangedRequest extends AwaitingRequest<DataReceiv
 		}
 	}
 
+	@SuppressWarnings("BooleanMethodIsAlwaysInverted")
 	boolean hasMore() {
 		return count > 0;
 	}

--- a/ble/src/main/java/no/nordicsemi/android/ble/WriteRequest.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/WriteRequest.java
@@ -75,15 +75,23 @@ public final class WriteRequest extends SimpleValueRequest<DataSentCallback> imp
 				 @IntRange(from = 0) final int offset, @IntRange(from = 0) final int length,
 				 @WriteType final int writeType) {
 		super(type, characteristic);
-		this.data = copy(data, offset, length);
+		this.data = Bytes.copy(data, offset, length);
 		this.writeType = writeType;
+	}
+
+	WriteRequest(@NonNull final Type type, @Nullable final BluetoothGattCharacteristic characteristic,
+				 @Nullable final byte[] data,
+				 @IntRange(from = 0) final int offset, @IntRange(from = 0) final int length) {
+		super(type, characteristic);
+		this.data = Bytes.copy(data, offset, length);
+		this.writeType = 0;
 	}
 
 	WriteRequest(@NonNull final Type type, @Nullable final BluetoothGattDescriptor descriptor,
 				 @Nullable final byte[] data,
 				 @IntRange(from = 0) final int offset, @IntRange(from = 0) final int length) {
 		super(type, descriptor);
-		this.data = copy(data, offset, length);
+		this.data = Bytes.copy(data, offset, length);
 		this.writeType = BluetoothGattCharacteristic.WRITE_TYPE_DEFAULT;
 	}
 
@@ -268,6 +276,7 @@ public final class WriteRequest extends SimpleValueRequest<DataSentCallback> imp
 
 	/**
 	 * Returns whether there are more bytes to be sent from this Write Request.
+	 *
 	 * @return True if not all data were sent, false if the request is complete.
 	 */
 	boolean hasMore() {
@@ -276,21 +285,11 @@ public final class WriteRequest extends SimpleValueRequest<DataSentCallback> imp
 
 	/**
 	 * Returns the write type that should be used to send the data.
+	 *
 	 * @return The write type.
 	 */
 	@WriteType
 	int getWriteType() {
 		return writeType;
-	}
-
-	private static byte[] copy(@Nullable final byte[] value,
-							   @IntRange(from = 0) final int offset,
-							   @IntRange(from = 0) final int length) {
-		if (value == null || offset > value.length)
-			return null;
-		final int maxLength = Math.min(value.length - offset, length);
-		final byte[] copy = new byte[maxLength];
-		System.arraycopy(value, offset, copy, 0, maxLength);
-		return copy;
 	}
 }

--- a/ble/src/main/java/no/nordicsemi/android/ble/callback/DataSentCallback.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/callback/DataSentCallback.java
@@ -31,7 +31,8 @@ import no.nordicsemi.android.ble.data.DataSplitter;
 public interface DataSentCallback {
 
 	/**
-	 * Callback received each time the value was written to a characteristic or descriptor.
+	 * Callback received each time the value was written to a characteristic or descriptor,
+	 * or was read from the server characteristic or descriptor.
 	 *
 	 * @param device the target device.
 	 * @param data the data sent. If the {@link DataSplitter} was used, this contains the full data.

--- a/ble/src/main/java/no/nordicsemi/android/ble/callback/FailCallback.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/callback/FailCallback.java
@@ -33,6 +33,7 @@ public interface FailCallback {
 	int REASON_REQUEST_FAILED = -4;
 	int REASON_TIMEOUT = -5;
 	int REASON_VALIDATION = -6;
+	int REASON_CANCELLED = -7;
 	int REASON_BLUETOOTH_DISABLED = -100;
 
 	/**
@@ -44,7 +45,8 @@ public interface FailCallback {
 	 *               {@link #REASON_DEVICE_DISCONNECTED}, {@link #REASON_TIMEOUT},
 	 *               {@link #REASON_DEVICE_NOT_SUPPORTED} (only for Connect request),
 	 *               {@link #REASON_BLUETOOTH_DISABLED}, {@link #REASON_NULL_ATTRIBUTE},
-	 *               {@link #REASON_VALIDATION} or {@link #REASON_REQUEST_FAILED} (for other reason).
+	 *               {@link #REASON_VALIDATION}, {@link #REASON_CANCELLED}
+	 *               or {@link #REASON_REQUEST_FAILED} (for other reason).
 	 */
 	void onRequestFailed(@NonNull final BluetoothDevice device, final int status);
 }

--- a/ble/src/main/java/no/nordicsemi/android/ble/data/Data.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/data/Data.java
@@ -196,6 +196,7 @@ public class Data implements Parcelable {
 		return mValue != null ? mValue.length : 0;
 	}
 
+	@NonNull
 	@Override
 	public String toString() {
 		if (size() == 0)

--- a/ble/src/main/java/no/nordicsemi/android/ble/utils/ParserUtils.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/utils/ParserUtils.java
@@ -27,6 +27,7 @@ import android.bluetooth.BluetoothGattDescriptor;
 import android.bluetooth.BluetoothProfile;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import no.nordicsemi.android.ble.PhyRequest;
 import no.nordicsemi.android.ble.annotation.BondState;
 import no.nordicsemi.android.ble.annotation.ConnectionState;
@@ -49,15 +50,15 @@ import static no.nordicsemi.android.ble.BleManager.PAIRING_VARIANT_PIN;
 public class ParserUtils {
 	protected final static char[] HEX_ARRAY = "0123456789ABCDEF".toCharArray();
 
-	public static String parse(final BluetoothGattCharacteristic characteristic) {
+	public static String parse(@NonNull final BluetoothGattCharacteristic characteristic) {
 		return parse(characteristic.getValue());
 	}
 
-	public static String parse(final BluetoothGattDescriptor descriptor) {
+	public static String parse(@NonNull final BluetoothGattDescriptor descriptor) {
 		return parse(descriptor.getValue());
 	}
 
-	public static String parse(final byte[] data) {
+	public static String parse(@Nullable final byte[] data) {
 		if (data == null || data.length == 0)
 			return "";
 
@@ -72,7 +73,7 @@ public class ParserUtils {
 		return "(0x) " + new String(out);
 	}
 
-	public static String parseDebug(final byte[] data) {
+	public static String parseDebug(@Nullable final byte[] data) {
 		if (data == null || data.length == 0)
 			return "null";
 

--- a/ble/src/main/java/no/nordicsemi/android/ble/utils/ParserUtils.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/utils/ParserUtils.java
@@ -72,6 +72,19 @@ public class ParserUtils {
 		return "(0x) " + new String(out);
 	}
 
+	public static String parseDebug(final byte[] data) {
+		if (data == null || data.length == 0)
+			return "null";
+
+		final char[] out = new char[data.length * 2];
+		for (int j = 0; j < data.length; j++) {
+			int v = data[j] & 0xFF;
+			out[j * 2] = HEX_ARRAY[v >>> 4];
+			out[j * 2 + 1] = HEX_ARRAY[v & 0x0F];
+		}
+		return "0x" + new String(out);
+	}
+
 	@NonNull
 	public static String pairingVariantToString(@PairingVariant final int variant) {
 		switch (variant) {

--- a/build.gradle
+++ b/build.gradle
@@ -8,10 +8,8 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.5.3'
-        /*
-        classpath "com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4"
-        classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
-        */
+
+        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.2'
+        classpath 'com.android.tools.build:gradle:3.5.3'
         /*
         classpath "com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4"
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,12 +9,23 @@
 
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx1536m
-
-android.enableJetifier=true
-android.useAndroidX=true
 
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
+android.useAndroidX=true
+
+VERSION_NAME=2.2.0-alpha01
+GROUP=no.nordicsemi.android
+
+POM_DESCRIPTION=Bluetooth Low Energy library for Android
+POM_URL=https://github.com/NordicSemiconductor/Android-BLE-Library
+POM_SCM_URL=https://github.com/NordicSemiconductor/Android-BLE-Library
+POM_SCM_CONNECTION=scm:git@github.com:NordicSemiconductor/Android-BLE-Library.git
+POM_SCM_DEV_CONNECTION=scm:git@github.com:NordicSemiconductor/Android-BLE-Library.git
+POM_LICENCE=BSD 3-Clause
+POM_LICENCE_NAME=The BSD 3-Clause License
+POM_LICENCE_URL=http://opensource.org/licenses/BSD-3-Clause
+POM_DEVELOPER_ID=nordic
+POM_DEVELOPER_NAME=Nordic Semiconductor ASA

--- a/gradle/gradle-bintray-push.gradle
+++ b/gradle/gradle-bintray-push.gradle
@@ -1,0 +1,127 @@
+apply plugin: 'maven'
+apply plugin: 'com.jfrog.bintray'
+
+version = VERSION_NAME
+group   = GROUP
+
+afterEvaluate { project ->
+    task install(type: Upload) {
+        repositories.mavenInstaller {
+            configuration = configurations.archives
+
+            pom.groupId = GROUP
+            pom.artifactId = POM_ARTIFACT_ID
+            pom.version = VERSION_NAME
+
+            pom.project {
+                name POM_NAME
+                packaging POM_PACKAGING
+                description POM_DESCRIPTION
+                url POM_URL
+
+                scm {
+                    url POM_SCM_URL
+                    connection POM_SCM_CONNECTION
+                    developerConnection POM_SCM_DEV_CONNECTION
+                }
+
+                licenses {
+                    license {
+                        name POM_LICENCE_NAME
+                        url POM_LICENCE_URL
+                    }
+                }
+
+                developers {
+                    developer {
+                        id POM_DEVELOPER_ID
+                        name POM_DEVELOPER_NAME
+                    }
+                }
+            }
+        }
+    }
+
+    task javadoc(type: Javadoc) {
+        failOnError false
+        source = android.sourceSets.main.java.sourceFiles
+
+        title = POM_DESCRIPTION
+
+        options.links("https://docs.oracle.com/javase/8/docs/api/")
+        options.linksOffline("https://d.android.com/reference","${android.sdkDirectory}/docs/reference")
+
+        classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
+        classpath += configurations.compile
+
+        // We're excluding these generated files
+        exclude '**/BuildConfig.java'
+        exclude '**/R.java'
+    }
+
+    task androidJavadocsJar(type: Jar, dependsOn: javadoc) {
+        classifier = 'javadoc'
+        from javadoc.destinationDir
+    }
+
+    task androidSourcesJar(type: Jar) {
+        classifier = 'sources'
+        from android.sourceSets.main.java.source
+    }
+
+    if (JavaVersion.current().isJava8Compatible()) {
+        allprojects {
+            tasks.withType(Javadoc) {
+                options.addStringOption('Xdoclint:none', '-quiet')
+            }
+        }
+    }
+
+    artifacts {
+        archives androidSourcesJar
+        archives androidJavadocsJar
+    }
+}
+
+// Bintray
+Properties properties = new Properties()
+properties.load(project.rootProject.file('local.properties').newDataInputStream())
+
+bintray {
+    user = properties.getProperty("BINTRAY_USER")
+    key  = properties.getProperty("BINTRAY_APIKEY")
+
+    configurations = ['archives']
+    pkg {
+        name = GROUP + ":" + POM_ARTIFACT_ID
+        desc = POM_DESCRIPTION
+
+        userOrg = properties.getProperty("BINTRAY_USER_ORG")
+        repo    = properties.getProperty("BINTRAY_REPO")
+
+        websiteUrl      = POM_URL
+        issueTrackerUrl = POM_URL + "/issues"
+        vcsUrl          = POM_URL + ".git"
+
+        licenses = [POM_LICENCE]
+
+        publish = true
+        publicDownloadNumbers = true
+
+        version {
+            desc = POM_DESCRIPTION
+            vcsTag = "v" + VERSION_NAME
+            gpg {
+                sign = true // Determines whether to GPG sign the files. The default is false
+                passphrase = properties.getProperty("BINTRAY_GPG_PASSWORD") // Optional. The passphrase for GPG signing'
+            }
+            // Optional configuration for Maven Central sync of the version
+            mavenCentralSync {
+                sync = true //[Default: true] Determines whether to sync the version to Maven Central.
+                user = properties.getProperty("SONATYPE_NEXUS_USERNAME") //OSS user token: mandatory
+                password = properties.getProperty("SONATYPE_NEXUS_PASSWORD") //OSS user password: mandatory
+                close = '1' //Optional property. By default the staging repository is closed and artifacts are released to Maven Central. You can optionally turn this behaviour off (by puting 0 as value) and release the version manually.
+            }
+        }
+    }
+}

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Feb 01 10:44:39 CET 2019
+#Thu Jan 02 09:54:43 CET 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip


### PR DESCRIPTION
This PR adds GATT server support to Android BLE Library. All features should be available starting from Android 4.3 (API 18).

### GATT Server
GATT server is a local attribute table on the Android device. It may be used by the remote device to send and read data from. The phone can also send notifications/indications when enabled by the remote side.
There exists only one GATT server on the device. Each connected peripheral discovers a sum of services created by all apps and the system.

### Usage
First, a `BleServerManager` needs to be created. You need to override this class and implement `initializeServer()` method.
Use `service(...)`, `characteristic(...)` and `descriptor(...)` helpler methods. If you want a characteristic or a descriptor to be shared between multiple connected devices (assuming you support multiple connections), use `sharedCharacteristic(...)` and `sharedDescriptor(...)` instead.

```java
public class ServerManager extends BleServerManager<BleServerManagerCallbacks> {

	ServerManager(@NonNull final Context context) {
		super(context);
	}

	@NonNull
	@Override
	protected List<BluetoothGattService> initializeServer() {
		return Collections.singletonList(
				service(SERVICE_UUID,
				characteristic(CHAR_UUID,
						BluetoothGattCharacteristic.PROPERTY_WRITE // properties
								| BluetoothGattCharacteristic.PROPERTY_NOTIFY
								| BluetoothGattCharacteristic.PROPERTY_EXTENDED_PROPS,
						BluetoothGattCharacteristic.PERMISSION_WRITE, // permissions
						null, // initial data
						cccd(), reliableWrite(), description("Some description", false) // descriptors
				))
		);
	}
}
```

When server is implemented, instantiate it. For each `BleManager` instance (connection), pass the server using `manager.useServer(server)`.
```java
// Create server instance (one per all connections!)
final ServerManager serverManager = new ServerManager(context);
serverManager.setManagerCallbacks(this);
// [ ...]

final ConnectionManager manager = new ConnectionManager(context);
manager.setManagerCallbacks(this);
// Use the manager with the server
manager.useServer(serverManager);
// And connect
manager.connect(bluetoothDevice)
	.retry(3, 100)
	.suseAutoConnect(false)
	.done(device -> ...)
	.fail(device, status -> ...)
	.timeout(TIMEOUT)
	.enqueue();
```

Then, you may enqueue server requests just like the client ones. Here's the list of new requests:
1. sendNotification - sends a notification from given characteristic
2. sendIndication - sends an indication from given characteristic
3. waitForRead - waits until a read request on given characteristic or descriptor
4. waitForWrite - waits for write request or write command on given characteristic or for write request on given descriptor
5. setCharacteristicValue - sets characteristic value; the value will be available to be read by the remote device
6. setDesciptorValue - sets descriptorvalue; the value will be available to be read by the remote device
7. waitForEnablingNotifications - waits until the notifications on given characteristic are enabled
8. waitForEnablingIndications - waits until the indications on given characteristic are enabled

And a write handler:
1. setWriteCallback - sets a callback that will be invoked with data written to the given characteristic or rescriptor