### PR TITLE
Version 2.2.0-alpha06

### DIFF
--- a/ble/build.gradle
+++ b/ble/build.gradle
@@ -7,7 +7,6 @@ android {
         minSdkVersion 18
         targetSdkVersion 29
         versionCode 27
-        versionName VERSION_NAME
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/ble/src/main/java/no/nordicsemi/android/ble/BleServerManager.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/BleServerManager.java
@@ -108,6 +108,9 @@ public abstract class BleServerManager implements ILogger {
 		}
 		serverServices = null;
 		for (BleManager manager: managers) {
+			// closeServer() must be called before close(). Otherwise close() would remove
+			// the manager from managers list while iterating this loop.
+			manager.closeServer();
 			manager.close();
 		}
 		managers.clear();

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,7 +16,7 @@
 # org.gradle.parallel=true
 android.useAndroidX=true
 
-VERSION_NAME=2.2.0-alpha05
+VERSION_NAME=2.2.0-alpha06
 GROUP=no.nordicsemi.android
 
 POM_DESCRIPTION=Bluetooth Low Energy library for Android


### PR DESCRIPTION
Bugs fixed:
* Closing server was causing NPE when managers were closing.
* Fixed NPE when Request Handler was not initialized. This is a breaking change, as `getGattCallbacks()` is now called in the constructor, which implicates that it may not return explicitly initialized field .  