### PR TITLE
Fix request type for sending notification

### DIFF
--- a/ble/src/main/java/no/nordicsemi/android/ble/BleManager.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/BleManager.java
@@ -1374,7 +1374,7 @@ public abstract class BleManager<E extends BleManagerCallbacks> implements ILogg
 	@NonNull
 	protected WriteRequest sendNotification(@Nullable final BluetoothGattCharacteristic serverCharacteristic,
 											@Nullable final Data data) {
-		return Request.newWriteRequest(serverCharacteristic, data != null ? data.getValue() : null)
+		return Request.newNotificationRequest(serverCharacteristic, data != null ? data.getValue() : null)
 				.setRequestHandler(requestHandler);
 	}
 


### PR DESCRIPTION
I found a bug when implementing ServerManager.
The request type of sending notification from server is incorrect. 