### PR TITLE
Fix server manager usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,7 +327,7 @@ class MyBleManager extends BleManager<BleManagerCallbacks> {
 					.getService(SERVICE_UUID)
 					.getCharacteristic(CHAR_UUID);
 			
-            //  set write callback, if you need
+			//  set write callback, if you need
 			setWriteCallback(serverCharacteristic)
 					.with((device, data) ->
 						sendNotification(otherCharacteristic, "any data".getBytes())

--- a/README.md
+++ b/README.md
@@ -291,11 +291,15 @@ serverManager.setManagerCallbacks(this);
 ```
 Set the server manager for each client connection:
 ```java
+// e.g. at BleServerManagerCallbacks#onDeviceConnectedToServer(@NonNull final BluetoothDevice device)
 final MyBleManager manager = new MyBleManager(context);
 manager.setManagerCallbacks(this);
 // Use the manager with the server
 manager.useServer(serverManager);
+//  set connected device
+manager.connect(device).enqueue()
 // [...]
+
 ```
 The `BleServermanagerCallbacks.onServerReady()` will be invoked when all service were added.
 You may initiate your connection there.
@@ -322,6 +326,14 @@ class MyBleManager extends BleManager<BleManagerCallbacks> {
 			serverCharacteristic = server
 					.getService(SERVICE_UUID)
 					.getCharacteristic(CHAR_UUID);
+			
+            //  set write callback, if you need
+			setWriteCallback(serverCharacteristic)
+					.with((device, data) ->
+						sendNotification(otherCharacteristic, "any data".getBytes())
+								.enqueue()
+					);
+            }
 		}
 		
 		// [...]

--- a/ble/src/main/java/no/nordicsemi/android/ble/BleManager.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/BleManager.java
@@ -26,6 +26,7 @@ import android.bluetooth.BluetoothGatt;
 import android.bluetooth.BluetoothGattCallback;
 import android.bluetooth.BluetoothGattCharacteristic;
 import android.bluetooth.BluetoothGattDescriptor;
+import android.bluetooth.BluetoothGattServer;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
@@ -48,6 +49,7 @@ import no.nordicsemi.android.ble.annotation.PairingVariant;
 import no.nordicsemi.android.ble.annotation.PhyMask;
 import no.nordicsemi.android.ble.annotation.PhyOption;
 import no.nordicsemi.android.ble.callback.ConnectionPriorityCallback;
+import no.nordicsemi.android.ble.callback.DataReceivedCallback;
 import no.nordicsemi.android.ble.callback.FailCallback;
 import no.nordicsemi.android.ble.callback.MtuCallback;
 import no.nordicsemi.android.ble.data.Data;
@@ -1807,5 +1809,28 @@ public abstract class BleManager<E extends BleManagerCallbacks> implements ILogg
 	 */
 	protected abstract class BleManagerGattCallback extends BleManagerHandler {
 		// All methods defined in the super class.
+
+		private BluetoothGattCharacteristic serverCharacteristic;
+		private BluetoothGattCharacteristic otherCharacteristic;
+
+		@Override
+		protected void onServerReady(@NonNull final BluetoothGattServer server) {
+			UUID SERVICE_UUID = UUID.randomUUID();
+			UUID CHAR_UUID = UUID.randomUUID();
+
+			// Obtain your server attributes.
+			serverCharacteristic = server
+					.getService(SERVICE_UUID)
+					.getCharacteristic(CHAR_UUID);
+
+			//  set write callback, if you need
+			setWriteCallback(serverCharacteristic)
+					.with((device, data) ->
+						sendNotification(otherCharacteristic, "any data".getBytes())
+								.enqueue()
+					);
+			}
+		}
+
 	}
 }

--- a/ble/src/main/java/no/nordicsemi/android/ble/BleManager.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/BleManager.java
@@ -26,7 +26,6 @@ import android.bluetooth.BluetoothGatt;
 import android.bluetooth.BluetoothGattCallback;
 import android.bluetooth.BluetoothGattCharacteristic;
 import android.bluetooth.BluetoothGattDescriptor;
-import android.bluetooth.BluetoothGattServer;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
@@ -49,7 +48,6 @@ import no.nordicsemi.android.ble.annotation.PairingVariant;
 import no.nordicsemi.android.ble.annotation.PhyMask;
 import no.nordicsemi.android.ble.annotation.PhyOption;
 import no.nordicsemi.android.ble.callback.ConnectionPriorityCallback;
-import no.nordicsemi.android.ble.callback.DataReceivedCallback;
 import no.nordicsemi.android.ble.callback.FailCallback;
 import no.nordicsemi.android.ble.callback.MtuCallback;
 import no.nordicsemi.android.ble.data.Data;
@@ -1809,28 +1807,5 @@ public abstract class BleManager<E extends BleManagerCallbacks> implements ILogg
 	 */
 	protected abstract class BleManagerGattCallback extends BleManagerHandler {
 		// All methods defined in the super class.
-
-		private BluetoothGattCharacteristic serverCharacteristic;
-		private BluetoothGattCharacteristic otherCharacteristic;
-
-		@Override
-		protected void onServerReady(@NonNull final BluetoothGattServer server) {
-			UUID SERVICE_UUID = UUID.randomUUID();
-			UUID CHAR_UUID = UUID.randomUUID();
-
-			// Obtain your server attributes.
-			serverCharacteristic = server
-					.getService(SERVICE_UUID)
-					.getCharacteristic(CHAR_UUID);
-
-			//  set write callback, if you need
-			setWriteCallback(serverCharacteristic)
-					.with((device, data) ->
-						sendNotification(otherCharacteristic, "any data".getBytes())
-								.enqueue()
-					);
-			}
-		}
-
 	}
 }


### PR DESCRIPTION
I implemented GATT server with `BleServerManager`.
The usage in `README.md` was a bit unkind for me.

After read [GATT server support PR](https://github.com/NordicSemiconductor/Android-BLE-Library/pull/143), I understood how to use `BleServerManager`.

I think it is better to add some usage for GATT server implementation with `BleServerManager`.