### PR TITLE
Version 2.2.0-alpha09

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Features available in version 2.2.0:
    *mCallbacks* was renamed to *callbacks*, and it got deprecated.
 6. Breaking change: `BleManager` is no longer a generic class.
 7. Breaking change: `setGattCallbacks(BleManagerCallbacks)` has been deprecated. Instead, use new 
-   `setDisconnectCallback(DisconnectCallback)` and `setBondingCallback(BondingCallback)`. For other
+   `setConnectionObserver(ConnectionObserver)` and `setBondingObserver(BondingObserver)`. For other
    callbacks, check out the deprecation messages in `BleManagerCallbacks` interface. 
 The API of version 2.2.0 is not finished and may slightly change in the near future.
 
@@ -248,7 +248,7 @@ To connect to a Bluetooth LE device using GATT, create a manager instance:
 
 ```java
 final MyBleManager manager = new MyBleManager(context);
-manager.setDisconnectCallback(abortCallback);
+manager.setConnectionObserver(connectionObserver);
 manager.connect(device)
 	.timeout(100000)
 	.retry(3, 100)
@@ -297,8 +297,8 @@ Set the server manager for each client connection:
 ```java
 // e.g. at BleServerManagerCallbacks#onDeviceConnectedToServer(@NonNull final BluetoothDevice device)
 final MyBleManager manager = new MyBleManager(context);
-manager.setDisconnectCallback(this);
-manager.setBondingCallback(this);
+manager.setConnectionObserver(this);
+manager.setBondingObserver(this);
 // Use the manager with the server
 manager.useServer(serverManager);
 // Set connected device

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ The last version not migrated to AndroidX is 2.0.5.
 
 To test the latest features, use the **alpha version**:
 ```grovy
-implementation 'no.nordicsemi.android:ble:2.2.0-alpha08'
+implementation 'no.nordicsemi.android:ble:2.2.0-alpha09'
 ```
 Features available in version 2.2.0:
 1. GATT Server support. This includes setting up the local GATT server on the Android device, new 

--- a/ble/src/main/java/no/nordicsemi/android/ble/BleManager.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/BleManager.java
@@ -47,8 +47,8 @@ import no.nordicsemi.android.ble.annotation.ConnectionState;
 import no.nordicsemi.android.ble.annotation.PairingVariant;
 import no.nordicsemi.android.ble.annotation.PhyMask;
 import no.nordicsemi.android.ble.annotation.PhyOption;
-import no.nordicsemi.android.ble.callback.BondingCallback;
-import no.nordicsemi.android.ble.callback.DisconnectCallback;
+import no.nordicsemi.android.ble.observer.BondingObserver;
+import no.nordicsemi.android.ble.observer.ConnectionObserver;
 import no.nordicsemi.android.ble.callback.ConnectionPriorityCallback;
 import no.nordicsemi.android.ble.callback.FailCallback;
 import no.nordicsemi.android.ble.callback.MtuCallback;
@@ -118,9 +118,9 @@ public abstract class BleManager implements ILogger {
 	@Deprecated
 	protected BleManagerCallbacks callbacks;
 	@Nullable
-	BondingCallback bondingCallback;
+	BondingObserver bondingObserver;
 	@Nullable
-	DisconnectCallback disconnectCallback;
+	ConnectionObserver connectionObserver;
 
 	private final BroadcastReceiver mPairingRequestBroadcastReceiver = new BroadcastReceiver() {
 		@Override
@@ -212,24 +212,24 @@ public abstract class BleManager implements ILogger {
 	}
 
 	/**
-	 * Sets the disconnect callback.
-	 * This callback will be called using the handler given in the constructor.
+	 * Sets the connection observer.
+	 * This callback will be called using the handler given in {@link BleManager#BleManager(Context, Handler)}.
 	 *
 	 * @param callback the callback listener.
 	 */
-	public final void setDisconnectCallback(@Nullable final DisconnectCallback callback) {
-		this.disconnectCallback = callback;
+	public final void setConnectionObserver(@Nullable final ConnectionObserver callback) {
+		this.connectionObserver = callback;
 	}
 
 	/**
-	 * Sets the callback, that will receive events related to bonding.
-	 * This callback will be called using the handler given in the constructor.
+	 * Sets the observer, that will receive events related to bonding.
+	 * This callback will be called using the handler given in {@link BleManager#BleManager(Context, Handler)}.
 	 *
 	 * @param callback the callback.
-	 * @see BondingCallback
+	 * @see BondingObserver
 	 */
-	public final void setBondingCallback(@Nullable final BondingCallback callback) {
-		this.bondingCallback = callback;
+	public final void setBondingObserver(@Nullable final BondingObserver callback) {
+		this.bondingObserver = callback;
 	}
 
 	/**

--- a/ble/src/main/java/no/nordicsemi/android/ble/BleManagerCallbacks.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/BleManagerCallbacks.java
@@ -28,14 +28,14 @@ import android.bluetooth.BluetoothGattCallback;
 import androidx.annotation.IntRange;
 import androidx.annotation.NonNull;
 import no.nordicsemi.android.ble.callback.BeforeCallback;
-import no.nordicsemi.android.ble.callback.BondingCallback;
-import no.nordicsemi.android.ble.callback.DisconnectCallback;
+import no.nordicsemi.android.ble.observer.BondingObserver;
+import no.nordicsemi.android.ble.observer.ConnectionObserver;
 import no.nordicsemi.android.ble.callback.FailCallback;
 import no.nordicsemi.android.ble.callback.SuccessCallback;
 
 /**
  * The BleManagerCallbacks should be overridden in your app and all the 'high level' callbacks
- * should be added there. See examples in Android nRF Blinky or Android nRF Toolbox.
+ * should be added there.
  *
  * @deprecated Use per-request callbacks instead. Check out deprecation descriptions for methods
  * below for details.
@@ -50,7 +50,7 @@ public interface BleManagerCallbacks {
 	 * or {@link #onError(BluetoothDevice, String, int)} in case of error.
 	 *
 	 * @param device the device that got connected.
-	 * @deprecated This is equivalent to calling {@link ConnectRequest#before(BeforeCallback)}.
+	 * @deprecated Use {@link ConnectionObserver#onDeviceConnecting(BluetoothDevice)} instead.
 	 */
 	@Deprecated
 	void onDeviceConnecting(@NonNull final BluetoothDevice device);
@@ -63,8 +63,7 @@ public interface BleManagerCallbacks {
 	 * {@link #onDeviceNotSupported(BluetoothDevice)} if required services have not been found.
 	 *
 	 * @param device the device that got connected.
-	 * @deprecated This information is internal to the manager. User should wait for
-	 * {@link ConnectRequest#done(SuccessCallback)} to be informed when the device is ready.
+	 * @deprecated Use {@link ConnectionObserver#onDeviceConnected(BluetoothDevice)} instead.
 	 */
 	@Deprecated
 	void onDeviceConnected(@NonNull final BluetoothDevice device);
@@ -73,9 +72,7 @@ public interface BleManagerCallbacks {
 	 * Called when user initialized disconnection.
 	 *
 	 * @param device the device that gets disconnecting.
-	 * @deprecated The device goes into DISCONNECTING state when {@link DisconnectRequest} has
-	 * started being executed. {@link DisconnectRequest#before(BeforeCallback)} will be called
-	 * at that moment.
+	 * @deprecated Use {@link ConnectionObserver#onDeviceDisconnecting(BluetoothDevice)} instead.
 	 */
 	@Deprecated
 	void onDeviceDisconnecting(@NonNull final BluetoothDevice device);
@@ -88,7 +85,8 @@ public interface BleManagerCallbacks {
 	 * Otherwise the {@link #onLinkLossOccurred(BluetoothDevice)} method will be called instead.
 	 *
 	 * @param device the device that got disconnected.
-	 * @deprecated Use {@link BleManager#setDisconnectCallback(DisconnectCallback)} instead.
+	 * @deprecated Use {@link ConnectionObserver#onDeviceDisconnected(BluetoothDevice, int)} or
+	 * {@link ConnectionObserver#onDeviceFailedToConnect(BluetoothDevice, int)} instead.
 	 */
 	@Deprecated
 	void onDeviceDisconnected(@NonNull final BluetoothDevice device);
@@ -100,8 +98,8 @@ public interface BleManagerCallbacks {
 	 * event.
 	 *
 	 * @param device the device that got disconnected due to a link loss.
-	 * @deprecated Use {@link BleManager#setDisconnectCallback(DisconnectCallback)} and await
-	 * {@link DisconnectCallback#REASON_LINK_LOSS} instead.
+	 * @deprecated Use {@link ConnectionObserver#onDeviceDisconnected(BluetoothDevice, int)} and
+	 * await {@link ConnectionObserver#REASON_LINK_LOSS} instead.
 	 */
 	@Deprecated
 	void onLinkLossOccurred(@NonNull final BluetoothDevice device);
@@ -130,7 +128,7 @@ public interface BleManagerCallbacks {
 	 * Method called when all initialization requests has been completed.
 	 *
 	 * @param device the device that get ready.
-	 * @deprecated Use {@link ConnectRequest#done(SuccessCallback)} instead.
+	 * @deprecated Use {@link ConnectionObserver#onDeviceReady(BluetoothDevice)} instead.
 	 */
 	@Deprecated
 	void onDeviceReady(@NonNull final BluetoothDevice device);
@@ -193,7 +191,7 @@ public interface BleManagerCallbacks {
 	 * device bond state is {@link BluetoothDevice#BOND_NONE}.
 	 *
 	 * @param device the device that requires bonding.
-	 * @deprecated Use {@link BleManager#setBondingCallback(BondingCallback)} instead.
+	 * @deprecated Use {@link BleManager#setBondingObserver(BondingObserver)} instead.
 	 */
 	@Deprecated
 	void onBondingRequired(@NonNull final BluetoothDevice device);
@@ -202,7 +200,7 @@ public interface BleManagerCallbacks {
 	 * Called when the device has been successfully bonded.
 	 *
 	 * @param device the device that got bonded.
-	 * @deprecated Use {@link BleManager#setBondingCallback(BondingCallback)} instead.
+	 * @deprecated Use {@link BleManager#setBondingObserver(BondingObserver)} instead.
 	 */
 	@Deprecated
 	void onBonded(@NonNull final BluetoothDevice device);
@@ -212,7 +210,7 @@ public interface BleManagerCallbacks {
 	 * {@link BluetoothDevice#BOND_NONE}.
 	 *
 	 * @param device the device that failed to bond.
-	 * @deprecated Use {@link BleManager#setBondingCallback(BondingCallback)} instead.
+	 * @deprecated Use {@link BleManager#setBondingObserver(BondingObserver)} instead.
 	 */
 	@Deprecated
 	void onBondingFailed(@NonNull final BluetoothDevice device);
@@ -235,6 +233,8 @@ public interface BleManagerCallbacks {
 	 * @param device the device that failed to connect due to lack of required services.
 	 * @deprecated {@link ConnectRequest#fail(FailCallback)} with reason
 	 * {@link FailCallback#REASON_DEVICE_NOT_SUPPORTED} will be called instead.
+	 * {@link ConnectionObserver#onDeviceDisconnected(BluetoothDevice, int)} with
+	 * {@link ConnectionObserver#REASON_NOT_SUPPORTED} can also be used.
 	 */
 	@Deprecated
 	void onDeviceNotSupported(@NonNull final BluetoothDevice device);

--- a/ble/src/main/java/no/nordicsemi/android/ble/observer/BondingObserver.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/observer/BondingObserver.java
@@ -1,11 +1,11 @@
-package no.nordicsemi.android.ble.callback;
+package no.nordicsemi.android.ble.observer;
 
 import android.bluetooth.BluetoothDevice;
 import android.bluetooth.BluetoothGatt;
 
 import androidx.annotation.NonNull;
 
-public interface BondingCallback {
+public interface BondingObserver {
 	/**
 	 * Called when an {@link BluetoothGatt#GATT_INSUFFICIENT_AUTHENTICATION} error occurred and the
 	 * device bond state is {@link BluetoothDevice#BOND_NONE}.

--- a/ble/src/main/java/no/nordicsemi/android/ble/observer/ConnectionObserver.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/observer/ConnectionObserver.java
@@ -19,7 +19,7 @@
  * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
  * USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package no.nordicsemi.android.ble.callback;
+package no.nordicsemi.android.ble.observer;
 
 import android.bluetooth.BluetoothDevice;
 import android.bluetooth.BluetoothGatt;
@@ -31,7 +31,7 @@ import no.nordicsemi.android.ble.ConnectRequest;
 /**
  * Additional callback for device disconnect with more information about state.
  */
-public interface DisconnectCallback {
+public interface ConnectionObserver {
 	/** The reason of disconnection is unknown. */
 	int REASON_UNKNOWN = -1;
 	/** The disconnection was initiated by the user. */
@@ -45,11 +45,51 @@ public interface DisconnectCallback {
 	 * and connection to the device was lost. Android will try to connect automatically.
 	 */
 	int REASON_LINK_LOSS = 3;
+	/** The device does not hav required services. */
+	int REASON_NOT_SUPPORTED = 4;
 	/**
 	 * The connection timed out. The device might have reboot, is out of range, turned off
 	 * or doesn't respond for another reason.
 	 */
 	int REASON_TIMEOUT = 10;
+
+	/**
+	 * Called when the Android device started connecting to given device.
+	 * The {@link #onDeviceConnected(BluetoothDevice)} will be called when the device is connected,
+	 * or {@link #onDeviceFailedToConnect(BluetoothDevice, int)} if connection will fail.
+	 *
+	 * @param device the device that got connected.
+	 */
+	void onDeviceConnecting(@NonNull final BluetoothDevice device);
+
+	/**
+	 * Called when the device has been connected. This does not mean that the application may start
+	 * communication. Service discovery will be handled automatically after this call.
+	 *
+	 * @param device the device that got connected.
+	 */
+	void onDeviceConnected(@NonNull final BluetoothDevice device);
+
+	/**
+	 * Called when the device failed to connect.
+	 * @param device the device that failed to connect.
+	 * @param reason the reason of failure.
+	 */
+	void onDeviceFailedToConnect(@NonNull final BluetoothDevice device, final int reason);
+
+	/**
+	 * Method called when all initialization requests has been completed.
+	 *
+	 * @param device the device that get ready.
+	 */
+	void onDeviceReady(@NonNull final BluetoothDevice device);
+
+	/**
+	 * Called when user initialized disconnection.
+	 *
+	 * @param device the device that gets disconnecting.
+	 */
+	void onDeviceDisconnecting(@NonNull final BluetoothDevice device);
 
 	/**
 	 * Called when the device has disconnected (when the callback returned

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,7 +16,7 @@
 # org.gradle.parallel=true
 android.useAndroidX=true
 
-VERSION_NAME=2.2.0-alpha08
+VERSION_NAME=2.2.0-alpha09
 GROUP=no.nordicsemi.android
 
 POM_DESCRIPTION=Bluetooth Low Energy library for Android


### PR DESCRIPTION
This version renames `DisconnectCallback` to `ConnectionObserver` and `BondingCallback` to `BondingObserver`. Some methods from the deprecated `BleManagerCallbacks` were restored in the new `ConnectionObserver`. 