### PR TITLE
Server improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,7 +291,7 @@ public class ServerManager extends BleServerManager {
 Instantiate the server and set the callback listener:
 ```java
 final ServerManager serverManager = new ServerManager(context);
-serverManager.setServerCallback(this);
+serverManager.setServerObserver(this);
 ```
 Set the server manager for each client connection:
 ```java

--- a/ble/src/main/java/no/nordicsemi/android/ble/observer/ServerObserver.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/observer/ServerObserver.java
@@ -1,11 +1,11 @@
-package no.nordicsemi.android.ble.callback;
+package no.nordicsemi.android.ble.observer;
 
 import android.bluetooth.BluetoothDevice;
 
 import androidx.annotation.NonNull;
 import no.nordicsemi.android.ble.BleServerManager;
 
-public interface ServerCallback {
+public interface ServerObserver {
 
 	/**
 	 * Called when the server was started and all services have been added successfully.


### PR DESCRIPTION
This PR renames `ServerCallback` (which previously was names `BleServerManagerCallbacks` to `ServerObserver` and places it into `observer` package.
The `onDeviceDisconnectedFromServer` callback does not have `reason` parameter, as it's not equal to what the client's corresponding callback would give. For example, when a connected device resets, the `onConnectionStateChange` would give status 8 (timeout), and the same callback in `BluetoothGattServerCallback` would give status 0 (success).
