### PR TITLE
Version 2.2.0-alpha13

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ The last version not migrated to AndroidX is 2.0.5.
 
 To test the latest features, use the **alpha version**:
 ```grovy
-implementation 'no.nordicsemi.android:ble:2.2.0-alpha12'
+implementation 'no.nordicsemi.android:ble:2.2.0-alpha13'
 ```
 Features available in version 2.2.0:
 1. GATT Server support. This includes setting up the local GATT server on the Android device, new 

--- a/ble/src/main/java/no/nordicsemi/android/ble/BleManagerHandler.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/BleManagerHandler.java
@@ -1690,13 +1690,14 @@ abstract class BleManagerHandler extends RequestHandler {
 					initQueue = null;
 					ready = false;
 
-					// Store the current value of the connected flag...
+					// Store the current value of the connected and servicesDiscovered flags...
 					final boolean wasConnected = connected;
-					// ...because this method sets the connected flag to false.
+					final boolean notSupported = servicesDiscovered;
+					// ...because the next method sets them to false.
 					notifyDeviceDisconnected(gatt.getDevice(), // this may call close()
 							timeout ?
 								ConnectionObserver.REASON_TIMEOUT :
-								servicesDiscovered ?
+									notSupported ?
 										ConnectionObserver.REASON_NOT_SUPPORTED :
 										mapDisconnectStatusToReason(status));
 
@@ -1720,7 +1721,7 @@ abstract class BleManagerHandler extends RequestHandler {
 					}
 					if (connectRequest != null) {
 						int reason;
-						if (servicesDiscovered)
+						if (notSupported)
 							reason = FailCallback.REASON_DEVICE_NOT_SUPPORTED;
 						else if (status == BluetoothGatt.GATT_SUCCESS)
 							reason = FailCallback.REASON_DEVICE_DISCONNECTED;

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,7 +16,7 @@
 # org.gradle.parallel=true
 android.useAndroidX=true
 
-VERSION_NAME=2.2.0-alpha12
+VERSION_NAME=2.2.0-alpha13
 GROUP=no.nordicsemi.android
 
 POM_DESCRIPTION=Bluetooth Low Energy library for Android


### PR DESCRIPTION
Bug fixing release. The failure about device not supported was not delivered to the `fail` callback.