### PR TITLE
Version 2.2.0-beta02

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,30 @@ For scanning, we recommend using
 [Android Scanner Compat Library](https://github.com/NordicSemiconductor/Android-Scanner-Compat-Library)
 which brings almost all recent features, introduced in Lollipop and later, to the older platforms. 
 
+### Version 2.2.0 (BETA)
+
+Features available in version 2.2.0:
+
+1. GATT Server support. This includes setting up the local GATT server on the Android device, new 
+   requests for server operations (*wait for read*, *wait for write*, *send notification*, *send indication*,
+   *set characteristic value*, *set descriptor value*).
+2. New conditional requests: *waif if* and *wait until*.
+3. BLE operations are no longer called from the main thread.
+4. There's a new option to set a handler for invoking callbacks. A handler can also be set per-callback.
+5. Breaking change: some fields in the *BleManager* got rid of the Hungarian Notation. In particular,
+   *mCallbacks* was renamed to *callbacks*, and it got deprecated.
+6. Breaking change: `BleManager` is no longer a generic class.
+7. Breaking change: `setGattCallbacks(BleManagerCallbacks)` has been deprecated. Instead, use new 
+   `setConnectionObserver(ConnectionObserver)` and `setBondingObserver(BondingObserver)`. For other
+   callbacks, check out the deprecation messages in `BleManagerCallbacks` interface. 
+8. To make the migration easier, a new class `LegacyBleManager` is still a generic class, and
+   `mCallbacks` field is working just like before. It's marked as deprecated.
+9. Breaking change: The protected method `getGattCallback()` in `BleManager` is now called from the 
+   constructor, so can't return a final field of a manager, as they are not initialized yet.
+   Instead, instantiate the `BleManagerGattCallback` class from there (see example below).
+   
+The API of version 2.2.0 is now finished. Some bugs may be fixed before it is promoted to 2.2.0 final.
+
 ## Importing
 
 #### Maven Central or jcenter
@@ -47,22 +71,8 @@ The last version not migrated to AndroidX is 2.0.5.
 
 To test the latest features, use the **beta version**:
 ```grovy
-implementation 'no.nordicsemi.android:ble:2.2.0-beta01'
+implementation 'no.nordicsemi.android:ble:2.2.0-beta02'
 ```
-Features available in version 2.2.0:
-1. GATT Server support. This includes setting up the local GATT server on the Android device, new 
-   requests for server operations (*wait for read*, *wait for write*, *send notification*, *send indication*,
-   *set characteristic value*, *set descriptor value*).
-2. New conditional requests: *waif if* and *wait until*.
-3. BLE operations are no longer called from the main thread.
-4. There's a new option to set a handler for invoking callbacks. A handler can also be set per-callback.
-5. Breaking change: some fields in the *BleManager* got rid of the Hungarian Notation. In particular,
-   *mCallbacks* was renamed to *callbacks*, and it got deprecated.
-6. Breaking change: `BleManager` is no longer a generic class.
-7. Breaking change: `setGattCallbacks(BleManagerCallbacks)` has been deprecated. Instead, use new 
-   `setConnectionObserver(ConnectionObserver)` and `setBondingObserver(BondingObserver)`. For other
-   callbacks, check out the deprecation messages in `BleManagerCallbacks` interface. 
-The API of version 2.2.0 is now finished. Some bugs may be fixed before it is promoted to 2.2.0 final.
 
 #### As a library module
 
@@ -113,9 +123,9 @@ class MyBleManager extends BleManager {
 
 	@Override
 	public void log(final int priority, @NonNull final String message) {
-		// Please, don't log in production.
-		if (Build.DEBUG || priority == Log.ERROR)
+		if (Build.DEBUG || priority == Log.ERROR) {
 			Log.println(priority, "MyBleManager", message);
+        }
 	}
 
 	/**
@@ -192,7 +202,7 @@ class MyBleManager extends BleManager {
 			firstCharacteristic = null;
 			secondCharacteristic = null;
 		}
-	};
+	}
 	
 	// Define your API.
 	
@@ -247,13 +257,24 @@ interface FluxCallbacks extends BleManagerCallbacks {
 To connect to a Bluetooth LE device using GATT, create a manager instance:
 
 ```java
-final MyBleManager manager = new MyBleManager(context);
-manager.setConnectionObserver(connectionObserver);
-manager.connect(device)
-	.timeout(100000)
-	.retry(3, 100)
-	.done(device -> Log.i(TAG, "Device initiated"))
-	.enqueue();
+class MyRepo {
+    private MyBleManager manager;
+
+    // [...]
+
+    void connect(@NonNull final BluetoothDevice device) {
+        manager = new MyBleManager(context);
+        manager.setConnectionObserver(connectionObserver);
+        manager.connect(device)
+        	.timeout(100000)
+        	.retry(3, 100)
+        	.done(device -> Log.i(TAG, "Device initiated"))
+        	.enqueue();
+    }
+    
+    // [...]
+
+}
 ```
 
 #### Adding GATT Server support
@@ -290,23 +311,44 @@ public class ServerManager extends BleServerManager {
 ```
 Instantiate the server and set the callback listener:
 ```java
-final ServerManager serverManager = new ServerManager(context);
-serverManager.setServerObserver(this);
+class MyRepo {
+    private ServerManager serverManager;
+
+    // [...]
+
+    void init() {
+        serverManager = new ServerManager(context);
+        serverManager.setServerObserver(this);
+    }
+    
+    // [...]
+
+}
 ```
 Set the server manager for each client connection:
 ```java
-// e.g. at BleServerManagerCallbacks#onDeviceConnectedToServer(@NonNull final BluetoothDevice device)
-final MyBleManager manager = new MyBleManager(context);
-manager.setConnectionObserver(this);
-manager.setBondingObserver(this);
-// Use the manager with the server
-manager.useServer(serverManager);
-// Set connected device
-manager.connect(device).enqueue()
-// [...]
+class MyRepo {
+    private ServerManager serverManager;
+    private MyBleManager manager;
 
+    // [...]
+
+    // This method may be called from e.g. 
+    // ServerObserver#onDeviceConnectedToServer(@NonNull final BluetoothDevice device)
+    void connect(@NonNull final BluetoothDevice device) {
+        manager = new MyBleManager(context);
+        manager.setConnectionObserver(this);
+        manager.setBondingObserver(this);
+        // Use the manager with the server.
+        manager.useServer(serverManager);
+
+        manager.connect(device)
+            // [...]
+            .enqueue();
+    }
+}
 ```
-The `BleServerManagerCallbacks.onServerReady()` will be invoked when all service were added.
+The `ServerObserver.onServerReady()` will be invoked when all service were added.
 You may initiate your connection there.
 
 In your client manager class, override the following method:
@@ -338,7 +380,6 @@ class MyBleManager extends BleManager {
 						sendNotification(otherCharacteristic, "any data".getBytes())
 								.enqueue()
 					);
-            }
 		}
 		
 		// [...]
@@ -348,7 +389,7 @@ class MyBleManager extends BleManager {
 			// [...]
 			serverCharacteristic = null;
 		}
-	};
+	}
 	
 	// [...]
 }
@@ -370,10 +411,8 @@ Find the simple example here [Android nRF Blinky](https://github.com/NordicSemic
 For an example how to use it from an Activity or a Service, check the base Activity and Service 
 classes in [nRF Toolbox](https://github.com/NordicSemiconductor/Android-nRF-Toolbox/tree/master/app/src/main/java/no/nordicsemi/android/nrftoolbox/profile).
 
-1. Define your device API by extending `BleManagerCallbacks`:
-[example](https://github.com/NordicSemiconductor/Android-nRF-Blinky/blob/master/app/src/main/java/no/nordicsemi/android/blinky/profile/BlinkyManagerCallbacks.java)
-2. Extend `BleManager` class and implement required methods:
-[example](https://github.com/NordicSemiconductor/Android-nRF-Blinky/blob/master/app/src/main/java/no/nordicsemi/android/blinky/profile/BlinkyManager.java)
+*Note:*
+nRF Toolbox has not yet been migrated to BLE Library v.2.2.0.
 
 ## Version 1.x
 

--- a/README.md
+++ b/README.md
@@ -254,14 +254,14 @@ class MyBleManager extends BleManager {
 To connect to a Bluetooth LE device using GATT, create a manager instance:
 
 ```java
-class MyRepo {
+class MyRepo implements ConnectionObserver {
     private MyBleManager manager;
 
     // [...]
 
     void connect(@NonNull final BluetoothDevice device) {
         manager = new MyBleManager(context);
-        manager.setConnectionObserver(connectionObserver);
+        manager.setConnectionObserver(this);
         manager.connect(device)
             .timeout(100000)
             .retry(3, 100)
@@ -292,15 +292,16 @@ public class ServerManager extends BleServerManager {
     @NonNull
     @Override
     protected List<BluetoothGattService> initializeServer() {
+        // In this example there's only one service, so singleton list is created.
         return Collections.singletonList(
             service(SERVICE_UUID,
-            characteristic(CHAR_UUID,
-                BluetoothGattCharacteristic.PROPERTY_WRITE // properties
-                  | BluetoothGattCharacteristic.PROPERTY_NOTIFY
-                  | BluetoothGattCharacteristic.PROPERTY_EXTENDED_PROPS,
-                BluetoothGattCharacteristic.PERMISSION_WRITE, // permissions
-                null, // initial data
-                cccd(), reliableWrite(), description("Some description", false) // descriptors
+                characteristic(CHAR_UUID,
+                    BluetoothGattCharacteristic.PROPERTY_WRITE // properties
+                      | BluetoothGattCharacteristic.PROPERTY_NOTIFY
+                      | BluetoothGattCharacteristic.PROPERTY_EXTENDED_PROPS,
+                    BluetoothGattCharacteristic.PERMISSION_WRITE, // permissions
+                    null, // initial data
+                    cccd(), reliableWrite(), description("Some description", false) // descriptors
             ))
         );
     }
@@ -308,7 +309,7 @@ public class ServerManager extends BleServerManager {
 ```
 Instantiate the server and set the callback listener:
 ```java
-class MyRepo {
+class MyRepo implements ServerObserver {
     private ServerManager serverManager;
 
     // [...]
@@ -324,7 +325,7 @@ class MyRepo {
 ```
 Set the server manager for each client connection:
 ```java
-class MyRepo {
+class MyRepo implements ConnectionObserver, BondingObserver {
     private ServerManager serverManager;
     private MyBleManager manager;
 
@@ -343,6 +344,8 @@ class MyRepo {
             // [...]
             .enqueue();
     }
+
+    // [...]
 }
 ```
 The `ServerObserver.onServerReady()` will be invoked when all service were added.

--- a/README.md
+++ b/README.md
@@ -104,153 +104,153 @@ act as API of your remote device, to separate lower BLE layer from the applicati
 ```java
 
 class MyBleManager extends BleManager {
-	final static UUID SERVICE_UUID = UUID.fromString("XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX");
-	final static UUID FIRST_CHAR   = UUID.fromString("XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX");
-	final static UUID SECOND_CHAR  = UUID.fromString("XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX");
+    final static UUID SERVICE_UUID = UUID.fromString("XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX");
+    final static UUID FIRST_CHAR   = UUID.fromString("XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX");
+    final static UUID SECOND_CHAR  = UUID.fromString("XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX");
 
-	// Client characteristics
-	private BluetoothGattCharacteristic firstCharacteristic, secondCharacteristic;
+    // Client characteristics
+    private BluetoothGattCharacteristic firstCharacteristic, secondCharacteristic;
 
-	MyBleManager(@NonNull final Context context) {
-		super(context);
-	}
+    MyBleManager(@NonNull final Context context) {
+        super(context);
+    }
 
-	@NonNull
-	@Override
-	protected BleManagerGattCallback getGattCallback() {
-		return new MyManagerGattCallback();
-	}
+    @NonNull
+    @Override
+    protected BleManagerGattCallback getGattCallback() {
+        return new MyManagerGattCallback();
+    }
 
-	@Override
-	public void log(final int priority, @NonNull final String message) {
-		if (Build.DEBUG || priority == Log.ERROR) {
-			Log.println(priority, "MyBleManager", message);
+    @Override
+    public void log(final int priority, @NonNull final String message) {
+        if (Build.DEBUG || priority == Log.ERROR) {
+            Log.println(priority, "MyBleManager", message);
         }
-	}
+    }
 
-	/**
-	 * BluetoothGatt callbacks object.
-	 */
-	private class MyManagerGattCallback extends BleManagerGattCallback {
+    /**
+     * BluetoothGatt callbacks object.
+     */
+    private class MyManagerGattCallback extends BleManagerGattCallback {
 
-		// This method will be called when the device is connected and services are discovered.
-		// You need to obtain references to the characteristics and descriptors that you will use.
-		// Return true if all required services are found, false otherwise.
-		@Override
-		public boolean isRequiredServiceSupported(@NonNull final BluetoothGatt gatt) {
-			final BluetoothGattService service = gatt.getService(SERVICE_UUID);
-			if (service != null) {
-				firstCharacteristic = service.getCharacteristic(FIRST_CHAR);
-				secondCharacteristic = service.getCharacteristic(SECOND_CHAR);
-			}
-			// Validate properties
-			boolean notify = false;
-			if (firstCharacteristic != null) {
-				final int properties = dataCharacteristic.getProperties();
-				notify = (properties & BluetoothGattCharacteristic.PROPERTY_NOTIFY) != 0;
-			}
-			boolean writeRequest = false;
-			if (secondCharacteristic != null) {
-				final int properties = controlPointCharacteristic.getProperties();
-				writeRequest = (properties & BluetoothGattCharacteristic.PROPERTY_WRITE) != 0;
-				secondCharacteristic.setWriteType(BluetoothGattCharacteristic.WRITE_TYPE_DEFAULT);
-			}
-			// Return true if all required services have been found
-			return firstCharacteristic != null && secondCharacteristic != null
-					&& notify && writeRequest;
-		}
+        // This method will be called when the device is connected and services are discovered.
+        // You need to obtain references to the characteristics and descriptors that you will use.
+        // Return true if all required services are found, false otherwise.
+        @Override
+        public boolean isRequiredServiceSupported(@NonNull final BluetoothGatt gatt) {
+            final BluetoothGattService service = gatt.getService(SERVICE_UUID);
+            if (service != null) {
+                firstCharacteristic = service.getCharacteristic(FIRST_CHAR);
+                secondCharacteristic = service.getCharacteristic(SECOND_CHAR);
+            }
+            // Validate properties
+            boolean notify = false;
+            if (firstCharacteristic != null) {
+                final int properties = dataCharacteristic.getProperties();
+                notify = (properties & BluetoothGattCharacteristic.PROPERTY_NOTIFY) != 0;
+            }
+            boolean writeRequest = false;
+            if (secondCharacteristic != null) {
+                final int properties = controlPointCharacteristic.getProperties();
+                writeRequest = (properties & BluetoothGattCharacteristic.PROPERTY_WRITE) != 0;
+                secondCharacteristic.setWriteType(BluetoothGattCharacteristic.WRITE_TYPE_DEFAULT);
+            }
+            // Return true if all required services have been found
+            return firstCharacteristic != null && secondCharacteristic != null
+                    && notify && writeRequest;
+        }
 
-		// If you have any optional services, allocate them here. Return true only if
-		// they are found. 
-		@Override
-		protected boolean isOptionalServiceSupported(@NonNull final BluetoothGatt gatt) {
-			return super.isOptionalServiceSupported(gatt);
-		}
+        // If you have any optional services, allocate them here. Return true only if
+        // they are found. 
+        @Override
+        protected boolean isOptionalServiceSupported(@NonNull final BluetoothGatt gatt) {
+            return super.isOptionalServiceSupported(gatt);
+        }
 
-		// Initialize your device here. Often you need to enable notifications and set required
-		// MTU or write some initial data. Do it here.
-		@Override
-		protected void initialize() {
-			// You may enqueue multiple operations. A queue ensures that all operations are 
-			// performed one after another, but it is not required.
-			beginAtomicRequestQueue()
-					.add(requestMtu(247) // Remember, GATT needs 3 bytes extra. This will allow packet size of 244 bytes.
-						.with((device, mtu) -> log(Log.INFO, "MTU set to " + mtu))
-						.fail((device, status) -> log(Log.WARN, "Requested MTU not supported: " + status)))
-					.add(setPreferredPhy(PhyRequest.PHY_LE_2M_MASK, PhyRequest.PHY_LE_2M_MASK, PhyRequest.PHY_OPTION_NO_PREFERRED)
-						.fail((device, status) -> log(Log.WARN, "Requested PHY not supported: " + status)))
-					.add(enableNotifications(firstCharacteristic))
-					.done(device -> log(Log.INFO, "Target initialized"))
-					.enqueue();			
-			// You may easily enqueue more operations here like such:
-			writeCharacteristic(secondCharacteristic, "Hello World!".getBytes())
-					.done(device -> log(Log.INFO, "Greetings sent"))
-					.enqueue();
-			// Set a callback for your notifications. You may also use waitForNotification(...).
-			// Both callbacks will be called when notification is received.
-			setNotificationCallback(firstCharacteristic, callback);
-			// If you need to send very long data using Write Without Response, use split()
-			// or define your own splitter in split(DataSplitter splitter, WriteProgressCallback cb). 
-			writeCharacteristic(secondCharacteristic, "Very, very long data that will no fit into MTU")
-					.split()
-					.enqueue();
-		}
+        // Initialize your device here. Often you need to enable notifications and set required
+        // MTU or write some initial data. Do it here.
+        @Override
+        protected void initialize() {
+            // You may enqueue multiple operations. A queue ensures that all operations are 
+            // performed one after another, but it is not required.
+            beginAtomicRequestQueue()
+                .add(requestMtu(247) // Remember, GATT needs 3 bytes extra. This will allow packet size of 244 bytes.
+                    .with((device, mtu) -> log(Log.INFO, "MTU set to " + mtu))
+                    .fail((device, status) -> log(Log.WARN, "Requested MTU not supported: " + status)))
+                .add(setPreferredPhy(PhyRequest.PHY_LE_2M_MASK, PhyRequest.PHY_LE_2M_MASK, PhyRequest.PHY_OPTION_NO_PREFERRED)
+                    .fail((device, status) -> log(Log.WARN, "Requested PHY not supported: " + status)))
+                .add(enableNotifications(firstCharacteristic))
+                .done(device -> log(Log.INFO, "Target initialized"))
+                .enqueue();			
+            // You may easily enqueue more operations here like such:
+            writeCharacteristic(secondCharacteristic, "Hello World!".getBytes())
+                .done(device -> log(Log.INFO, "Greetings sent"))
+                .enqueue();
+            // Set a callback for your notifications. You may also use waitForNotification(...).
+            // Both callbacks will be called when notification is received.
+            setNotificationCallback(firstCharacteristic, callback);
+            // If you need to send very long data using Write Without Response, use split()
+            // or define your own splitter in split(DataSplitter splitter, WriteProgressCallback cb). 
+            writeCharacteristic(secondCharacteristic, "Very, very long data that will no fit into MTU")
+                .split()
+                .enqueue();
+        }
 
-		@Override
-		protected void onDeviceDisconnected() {
-			// Device disconnected. Release your references here.
-			firstCharacteristic = null;
-			secondCharacteristic = null;
-		}
-	}
-	
-	// Define your API.
-	
-	private abstract class FluxHandler implements DataReceivedCallback {		
-		@Override
-		public void onDataReceived(@NonNull final BluetoothDevice device, @NonNull final Data data) {
-			if (data.getByte(0) == 0x01)
-				onFluxCapacitorEngaged();
-		}
-		
-		abstract void onFluxCapacitorEngaged();
-	}
-	
-	/** Initialize time machine. */
-	public void enableFluxCapacitor(final int year) {
-		waitForNotification(firstCharacteristic)
-			.trigger(
-					writeCharacteristic(secondCharacteristic, new FluxJumpRequest(year))
-						.done(device -> log(Log.INDO, "Power on command sent"))
-			 )
-			.with(new FluxHandler() {
-				public void onFluxCapacitorEngaged() {
-					log(Log.WARN, "Flux Capacitor enabled! Going back to the future in 3 seconds!");
-					callbacks.onFluxCapacitorEngaged();
-					
-					sleep(3000).enqueue();
-					write(secondCharacteristic, "Hold on!".getBytes())
-						.done(device -> log(Log.WARN, "It's " + year + "!"))
-						.fail((device, status) -> "Not enough flux? (status: " + status + ")")
-						.enqueue();
-				}
-			})
-			.enqueue();
-	}
-	
-	/** 
-	* Aborts time travel. Call during 3 sec after enabling Flux Capacitor and only if you don't 
-	* like 2020. 
-	*/
-	public void abort() {
-		cancelQueue();
-	}
+        @Override
+        protected void onDeviceDisconnected() {
+            // Device disconnected. Release your references here.
+            firstCharacteristic = null;
+            secondCharacteristic = null;
+        }
+    }
+    
+    // Define your API.
+    
+    private abstract class FluxHandler implements DataReceivedCallback {		
+        @Override
+        public void onDataReceived(@NonNull final BluetoothDevice device, @NonNull final Data data) {
+            if (data.getByte(0) == 0x01)
+                onFluxCapacitorEngaged();
+        }
+        
+        abstract void onFluxCapacitorEngaged();
+    }
+    
+    /** Initialize time machine. */
+    public void enableFluxCapacitor(final int year) {
+        waitForNotification(firstCharacteristic)
+            .trigger(
+                writeCharacteristic(secondCharacteristic, new FluxJumpRequest(year))
+                    .done(device -> log(Log.INDO, "Power on command sent"))
+             )
+            .with(new FluxHandler() {
+                public void onFluxCapacitorEngaged() {
+                    log(Log.WARN, "Flux Capacitor enabled! Going back to the future in 3 seconds!");
+                    callbacks.onFluxCapacitorEngaged();
+                    
+                    sleep(3000).enqueue();
+                    write(secondCharacteristic, "Hold on!".getBytes())
+                        .done(device -> log(Log.WARN, "It's " + year + "!"))
+                        .fail((device, status) -> "Not enough flux? (status: " + status + ")")
+                        .enqueue();
+                }
+            })
+            .enqueue();
+    }
+    
+    /** 
+    * Aborts time travel. Call during 3 sec after enabling Flux Capacitor and only if you don't 
+    * like 2020. 
+    */
+    public void abort() {
+        cancelQueue();
+    }
 }
 ```
 Create the callbacks for your device:
 ```java
 interface FluxCallbacks extends BleManagerCallbacks {
-	void onFluxCapacitorEngaged();
+    void onFluxCapacitorEngaged();
 }
 ```
 
@@ -266,10 +266,10 @@ class MyRepo {
         manager = new MyBleManager(context);
         manager.setConnectionObserver(connectionObserver);
         manager.connect(device)
-        	.timeout(100000)
-        	.retry(3, 100)
-        	.done(device -> Log.i(TAG, "Device initiated"))
-        	.enqueue();
+            .timeout(100000)
+            .retry(3, 100)
+            .done(device -> Log.i(TAG, "Device initiated"))
+            .enqueue();
     }
     
     // [...]
@@ -288,25 +288,25 @@ for making the initialization more readable.
 ```java
 public class ServerManager extends BleServerManager {
 
-	ServerManager(@NonNull final Context context) {
-		super(context);
-	}
+    ServerManager(@NonNull final Context context) {
+        super(context);
+    }
 
-	@NonNull
-	@Override
-	protected List<BluetoothGattService> initializeServer() {
-		return Collections.singletonList(
-				service(SERVICE_UUID,
-				characteristic(CHAR_UUID,
-						BluetoothGattCharacteristic.PROPERTY_WRITE // properties
-								| BluetoothGattCharacteristic.PROPERTY_NOTIFY
-								| BluetoothGattCharacteristic.PROPERTY_EXTENDED_PROPS,
-						BluetoothGattCharacteristic.PERMISSION_WRITE, // permissions
-						null, // initial data
-						cccd(), reliableWrite(), description("Some description", false) // descriptors
-				))
-		);
-	}
+    @NonNull
+    @Override
+    protected List<BluetoothGattService> initializeServer() {
+        return Collections.singletonList(
+            service(SERVICE_UUID,
+            characteristic(CHAR_UUID,
+                BluetoothGattCharacteristic.PROPERTY_WRITE // properties
+                  | BluetoothGattCharacteristic.PROPERTY_NOTIFY
+                  | BluetoothGattCharacteristic.PROPERTY_EXTENDED_PROPS,
+                BluetoothGattCharacteristic.PERMISSION_WRITE, // permissions
+                null, // initial data
+                cccd(), reliableWrite(), description("Some description", false) // descriptors
+            ))
+        );
+    }
 }
 ```
 Instantiate the server and set the callback listener:
@@ -354,44 +354,44 @@ You may initiate your connection there.
 In your client manager class, override the following method:
 ```java
 class MyBleManager extends BleManager {
-	// [...]	
+    // [...]	
 
-	// Server characteristics
-	private BluetoothGattCharacteristic serverCharacteristic;
+    // Server characteristics
+    private BluetoothGattCharacteristic serverCharacteristic;
 
-	// [...]
+    // [...]
 
-	/**
-	 * BluetoothGatt callbacks object.
-	 */
-	private class MyManagerGattCallback extends BleManagerGattCallback {
-		// [...]	
-	
-		@Override
-		protected void onServerReady(@NonNull final BluetoothGattServer server) {
-			// Obtain your server attributes.
-			serverCharacteristic = server
-					.getService(SERVICE_UUID)
-					.getCharacteristic(CHAR_UUID);
-			
-			//  set write callback, if you need
-			setWriteCallback(serverCharacteristic)
-					.with((device, data) ->
-						sendNotification(otherCharacteristic, "any data".getBytes())
-								.enqueue()
-					);
-		}
-		
-		// [...]
+    /**
+     * BluetoothGatt callbacks object.
+     */
+    private class MyManagerGattCallback extends BleManagerGattCallback {
+        // [...]	
+    
+        @Override
+        protected void onServerReady(@NonNull final BluetoothGattServer server) {
+            // Obtain your server attributes.
+            serverCharacteristic = server
+                .getService(SERVICE_UUID)
+                .getCharacteristic(CHAR_UUID);
+            
+            //  set write callback, if you need
+            setWriteCallback(serverCharacteristic)
+                .with((device, data) ->
+                    sendNotification(otherCharacteristic, "any data".getBytes())
+                        .enqueue()
+                );
+        }
+        
+        // [...]
 
-		@Override
-		protected void onDeviceDisconnected() {
-			// [...]
-			serverCharacteristic = null;
-		}
-	}
-	
-	// [...]
+        @Override
+        protected void onDeviceDisconnected() {
+            // [...]
+            serverCharacteristic = null;
+        }
+    }
+    
+    // [...]
 }
 ``` 
 

--- a/ble/build.gradle
+++ b/ble/build.gradle
@@ -27,7 +27,7 @@ android {
 dependencies {
     api 'androidx.annotation:annotation:1.1.0'
 
-    testImplementation 'junit:junit:4.12'
+    testImplementation 'junit:junit:4.13'
     androidTestImplementation 'androidx.test:runner:1.2.0'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
 }

--- a/ble/src/main/java/no/nordicsemi/android/ble/LegacyBleManager.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/LegacyBleManager.java
@@ -1,0 +1,36 @@
+package no.nordicsemi.android.ble;
+
+import android.content.Context;
+import android.os.Handler;
+
+import androidx.annotation.NonNull;
+
+/**
+ * When migrating from BLE Manager 2.1.1 to 2.2.0, the BleManager is no longer a template class.
+ * Callbacks need to be passed in other way, e.g. using LiveData, RxJava or with a callback,
+ * but the BleManager will not hold the callbacks reference.
+ *
+ * To make the migration easier, this class behaves the same way as the old BleManager.
+ * Replace the base class of your manager to LegacyBleManager.
+ * @param <E> the callbacks interface.
+ */
+@SuppressWarnings({"WeakerAccess", "unused", "deprecation"})
+@Deprecated
+public abstract class LegacyBleManager<E extends BleManagerCallbacks> extends BleManager {
+    protected E mCallbacks;
+
+    public LegacyBleManager(@NonNull final Context context) {
+        super(context);
+    }
+
+    public LegacyBleManager(@NonNull final Context context, @NonNull final Handler handler) {
+        super(context, handler);
+    }
+
+    @Override
+    public void setGattCallbacks(@NonNull final BleManagerCallbacks callbacks) {
+        super.setGattCallbacks(callbacks);
+        //noinspection unchecked
+        mCallbacks = (E) callbacks;
+    }
+}

--- a/ble/src/main/java/no/nordicsemi/android/ble/Request.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/Request.java
@@ -1179,7 +1179,7 @@ public abstract class Request {
 		}
 	}
 
-	void notifySuccess(@NonNull final BluetoothDevice device) {
+	boolean notifySuccess(@NonNull final BluetoothDevice device) {
 		if (!finished) {
 			finished = true;
 
@@ -1189,7 +1189,9 @@ public abstract class Request {
 				if (successCallback != null)
 					successCallback.onRequestCompleted(device);
 			});
+			return true;
 		}
+		return false;
 	}
 
 	void notifyFail(@NonNull final BluetoothDevice device, final int status) {

--- a/ble/src/main/java/no/nordicsemi/android/ble/TimeoutableRequest.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/TimeoutableRequest.java
@@ -196,12 +196,12 @@ public abstract class TimeoutableRequest extends Request {
 	}
 
 	@Override
-	void notifySuccess(@NonNull final BluetoothDevice device) {
+	boolean notifySuccess(@NonNull final BluetoothDevice device) {
 		if (!finished) {
 			handler.removeCallbacks(timeoutCallback);
 			timeoutCallback = null;
 		}
-		super.notifySuccess(device);
+		return super.notifySuccess(device);
 	}
 
 	@Override

--- a/ble/src/main/java/no/nordicsemi/android/ble/WaitForReadRequest.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/WaitForReadRequest.java
@@ -233,12 +233,12 @@ public final class WaitForReadRequest extends AwaitingRequest<DataSentCallback> 
 	}
 
 	@Override
-	void notifySuccess(@NonNull final BluetoothDevice device) {
+	boolean notifySuccess(@NonNull final BluetoothDevice device) {
 		handler.post(() -> {
 			if (valueCallback != null)
 				valueCallback.onDataSent(device, new Data(data));
 		});
-		super.notifySuccess(device);
+		return super.notifySuccess(device);
 	}
 
 	/**

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,7 +16,7 @@
 # org.gradle.parallel=true
 android.useAndroidX=true
 
-VERSION_NAME=2.2.0-beta01
+VERSION_NAME=2.2.0-beta02
 GROUP=no.nordicsemi.android
 
 POM_DESCRIPTION=Bluetooth Low Energy library for Android


### PR DESCRIPTION
Improvements:
* A new `LegacyBleManager` class added which should make the transition to 2.2.0 easier. It's still a generic class, like `BleManager` used to be.
* Readme updated.

Bugs fixed:
* `ConnectionPriorityRequest` should now complete at most after 200 ms. There were phones running Android 8+ there didn't seem to have native callback (#186).