### PR TITLE
Fixing chunked requests when awaiting request

### DIFF
--- a/ble/src/main/java/no/nordicsemi/android/ble/BleManagerHandler.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/BleManagerHandler.java
@@ -210,7 +210,7 @@ abstract class BleManagerHandler extends RequestHandler {
 	 * There may be only a single instance of such request at a time as this is a blocking request.
 	 */
 	@Nullable
-	private AwaitingRequest awaitingRequest;
+	private AwaitingRequest<?> awaitingRequest;
 
 	private final BroadcastReceiver bluetoothStateBroadcastReceiver = new BroadcastReceiver() {
 		@Override
@@ -2734,7 +2734,7 @@ abstract class BleManagerHandler extends RequestHandler {
 
 	private boolean checkCondition() {
 		if (awaitingRequest instanceof ConditionalWaitRequest) {
-			final ConditionalWaitRequest cwr = (ConditionalWaitRequest) awaitingRequest;
+			final ConditionalWaitRequest<?> cwr = (ConditionalWaitRequest<?>) awaitingRequest;
 			if (cwr.isFulfilled()) {
 				cwr.notifySuccess(bluetoothDevice);
 				awaitingRequest = null;
@@ -2817,7 +2817,7 @@ abstract class BleManagerHandler extends RequestHandler {
 		this.request = request;
 
 		if (request instanceof AwaitingRequest) {
-			final AwaitingRequest r = (AwaitingRequest) request;
+			final AwaitingRequest<?> r = (AwaitingRequest<?>) request;
 
 			// The WAIT_FOR_* request types may override the request with a trigger.
 			// This is to ensure that the trigger is done after the awaitingRequest was set.
@@ -2843,7 +2843,7 @@ abstract class BleManagerHandler extends RequestHandler {
 					   (r.characteristic.getProperties() & requiredProperty) != 0);
 			if (result) {
 				if (r instanceof ConditionalWaitRequest) {
-					final ConditionalWaitRequest cwr = (ConditionalWaitRequest) r;
+					final ConditionalWaitRequest<?> cwr = (ConditionalWaitRequest<?>) r;
 					if (cwr.isFulfilled()) {
 						cwr.notifyStarted(bluetoothDevice);
 						cwr.notifySuccess(bluetoothDevice);

--- a/ble/src/main/java/no/nordicsemi/android/ble/BleManagerHandler.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/BleManagerHandler.java
@@ -1146,8 +1146,16 @@ abstract class BleManagerHandler extends RequestHandler {
 
 	// Request Handler methods
 
-	@Override
-	final void enqueueFirst(@NonNull final Request request) {
+	/**
+	 * Enqueues the given request at the front of the the init or task queue, depending
+	 * on whether the initialization is in progress, or not.
+	 *
+	 * This method sets the {@link #operationInProgress} to false, assuming the newly added
+	 * request will be executed immediately after this method ends.
+	 *
+	 * @param request the request to be added.
+	 */
+	private final void enqueueFirst(@NonNull final Request request) {
 		final Deque<Request> queue = initInProgress ? initQueue : taskQueue;
 		queue.addFirst(request);
 		request.enqueued = true;

--- a/ble/src/main/java/no/nordicsemi/android/ble/BleManagerHandler.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/BleManagerHandler.java
@@ -1155,9 +1155,14 @@ abstract class BleManagerHandler extends RequestHandler {
 	 *
 	 * @param request the request to be added.
 	 */
-	private final void enqueueFirst(@NonNull final Request request) {
-		final Deque<Request> queue = initInProgress ? initQueue : taskQueue;
-		queue.addFirst(request);
+	private void enqueueFirst(@NonNull final Request request) {
+		final RequestQueue rq = requestQueue;
+		if (rq == null) {
+			final Deque<Request> queue = initInProgress ? initQueue : taskQueue;
+			queue.addFirst(request);
+		} else {
+			rq.addFirst(request);
+		}
 		request.enqueued = true;
 		// This ensures that the request that was put as first will be executed.
 		// The reason this was added is stated in

--- a/ble/src/main/java/no/nordicsemi/android/ble/RequestHandler.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/RequestHandler.java
@@ -7,17 +7,12 @@ abstract class RequestHandler implements CallbackHandler {
 	 * Enqueues the given request at the end of the the init or task queue, depending
 	 * on whether the initialization is in progress, or not.
 	 *
-	 * @param request the request to be added.
-	 */
-	abstract void enqueue(@NonNull final Request request);
-
-	/**
-	 * Enqueues the given request at the front of the the init or task queue, depending
-	 * on whether the initialization is in progress, or not.
+	 * This method will automatically try to execute the next request (not necessarily the
+	 * enqueued one).
 	 *
 	 * @param request the request to be added.
 	 */
-	abstract void enqueueFirst(@NonNull final Request request);
+	abstract void enqueue(@NonNull final Request request);
 
 	/**
 	 * Removes all enqueued requests from the queue.

--- a/ble/src/main/java/no/nordicsemi/android/ble/RequestQueue.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/RequestQueue.java
@@ -24,8 +24,8 @@ package no.nordicsemi.android.ble;
 
 import android.os.Handler;
 
+import java.util.Deque;
 import java.util.LinkedList;
-import java.util.Queue;
 
 import androidx.annotation.IntRange;
 import androidx.annotation.NonNull;
@@ -41,7 +41,7 @@ public class RequestQueue extends SimpleRequest {
 	 * A list of operations that will be executed together.
 	 */
 	@NonNull
-	private final Queue<Request> requests;
+	private final Deque<Request> requests;
 
 	RequestQueue() {
 		super(Type.SET);
@@ -113,6 +113,14 @@ public class RequestQueue extends SimpleRequest {
 		} else {
 			throw new IllegalArgumentException("Operation does not extend Request");
 		}
+	}
+
+	/**
+	 * Enqueues given request again in the request queue, putting it to the front of it.
+	 * @param request the request to be enqueued.
+	 */
+	void addFirst(@NonNull final Request request) {
+		requests.addFirst(request);
 	}
 
 	/**

--- a/ble/src/main/java/no/nordicsemi/android/ble/RequestQueue.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/RequestQueue.java
@@ -22,21 +22,27 @@
 
 package no.nordicsemi.android.ble;
 
+import android.bluetooth.BluetoothGatt;
 import android.os.Handler;
-
-import java.util.Deque;
-import java.util.LinkedList;
 
 import androidx.annotation.IntRange;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+
+import java.util.Deque;
+import java.util.LinkedList;
+
 import no.nordicsemi.android.ble.callback.BeforeCallback;
 import no.nordicsemi.android.ble.callback.FailCallback;
 import no.nordicsemi.android.ble.callback.InvalidRequestCallback;
 import no.nordicsemi.android.ble.callback.SuccessCallback;
+import no.nordicsemi.android.ble.exception.BluetoothDisabledException;
+import no.nordicsemi.android.ble.exception.DeviceDisconnectedException;
+import no.nordicsemi.android.ble.exception.InvalidRequestException;
+import no.nordicsemi.android.ble.exception.RequestFailedException;
 
 @SuppressWarnings("WeakerAccess")
-public class RequestQueue extends SimpleRequest {
+public class RequestQueue extends Request {
 	/**
 	 * A list of operations that will be executed together.
 	 */
@@ -106,6 +112,7 @@ public class RequestQueue extends SimpleRequest {
 			if (request.enqueued)
 				throw new IllegalStateException("Request already enqueued");
 			// Add
+			request.internalFail(this::notifyFail);
 			requests.add(request);
 			// Mark
 			request.enqueued = true;
@@ -117,6 +124,7 @@ public class RequestQueue extends SimpleRequest {
 
 	/**
 	 * Enqueues given request again in the request queue, putting it to the front of it.
+	 *
 	 * @param request the request to be enqueued.
 	 */
 	void addFirst(@NonNull final Request request) {
@@ -155,6 +163,62 @@ public class RequestQueue extends SimpleRequest {
 	}
 
 	/**
+	 * Synchronously waits until all enqueued requests are done. The queue will fail if any of
+	 * the enqueued requests fails. All following requests will be ignored.
+	 * <p>
+	 * Callbacks set using {@link #before(BeforeCallback)}, {@link #done(SuccessCallback)} and
+	 * {@link #fail(FailCallback)} will be ignored.
+	 * <p>
+	 * This method may not be called from the main (UI) thread.
+	 *
+	 * @throws RequestFailedException      thrown when the BLE request finished with status other
+	 *                                     than {@link BluetoothGatt#GATT_SUCCESS}.
+	 * @throws IllegalStateException       thrown when you try to call this method from the main
+	 *                                     (UI) thread.
+	 * @throws DeviceDisconnectedException thrown when the device disconnected before the request
+	 *                                     was completed.
+	 * @throws BluetoothDisabledException  thrown when the Bluetooth adapter has been disabled.
+	 * @throws InvalidRequestException     thrown when the request was called before the device was
+	 *                                     connected at least once (unknown device).
+	 * @throws InterruptedException        thrown when one of the request has failed with a timeout.
+	 */
+	public final void await() throws RequestFailedException, DeviceDisconnectedException,
+			BluetoothDisabledException, InvalidRequestException, InterruptedException {
+		assertNotMainThread();
+
+		final BeforeCallback bc = beforeCallback;
+		final SuccessCallback sc = successCallback;
+		final FailCallback fc = failCallback;
+		try {
+			syncLock.close();
+			final RequestCallback callback = new RequestCallback();
+			beforeCallback = null;
+			done(callback).fail(callback).invalid(callback).enqueue();
+
+			syncLock.block();
+			if (!callback.isSuccess()) {
+				if (callback.status == FailCallback.REASON_DEVICE_DISCONNECTED) {
+					throw new DeviceDisconnectedException();
+				}
+				if (callback.status == FailCallback.REASON_BLUETOOTH_DISABLED) {
+					throw new BluetoothDisabledException();
+				}
+				if (callback.status == FailCallback.REASON_TIMEOUT) {
+					throw new InterruptedException();
+				}
+				if (callback.status == RequestCallback.REASON_REQUEST_INVALID) {
+					throw new InvalidRequestException(this);
+				}
+				throw new RequestFailedException(this, callback.status);
+			}
+		} finally {
+			beforeCallback = bc;
+			successCallback = sc;
+			failCallback = fc;
+		}
+	}
+
+	/**
 	 * Returns the next {@link Request} to be enqueued.
 	 *
 	 * @return the next request.
@@ -176,6 +240,6 @@ public class RequestQueue extends SimpleRequest {
 	 * @return true, if not all operations were completed.
 	 */
 	boolean hasMore() {
-		return !requests.isEmpty();
+		return !finished && !requests.isEmpty();
 	}
 }


### PR DESCRIPTION
This PR tries to fix #200. 

**Problem:**
When the manager was awaiting a notification or atomic queue was started, the library was unable to send requests split into multiple chunks. `operationInProgress` wasn't cleared, as `awaitingRequest` was not `nil`, causing following requests to be queued, but not executed. The atomic queue or awaiting requests would timeout eventually.

**Solution:**
The PR resets the `operationInProgress` each time a request is added to the beginning of the queue.