### PR TITLE
Version 2.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,22 @@ project(':ble').projectDir = file('../Android-BLE-Library/ble')
 You may do the same with other modules available in this project. Keep in mind, that
 *ble-livedata* module requires Kotlin, but no special changes are required in the app.
 
+#### Setting up
+
+The library uses Java 1.8 features. Make sure your *build.gradle* includes the following 
+configuration:
+
+```groovy
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+    // For Kotlin projects additionally:
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
+```
+
 ## Usage
 
 A `BleManager` instance is responsible for connecting and communicating with a single peripheral.

--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ For scanning, we recommend using
 [Android Scanner Compat Library](https://github.com/NordicSemiconductor/Android-Scanner-Compat-Library)
 which brings almost all recent features, introduced in Lollipop and later, to the older platforms. 
 
-### Version 2.2.0
+### Version 2.2
 
-New features added in version 2.2.0:
+New features added in version 2.2:
 
 1. GATT Server support. This includes setting up the local GATT server on the Android device, new 
    requests for server operations: 
@@ -51,9 +51,9 @@ New features added in version 2.2.0:
 3. BLE operations are no longer called from the main thread.
 4. There's a new option to set a handler for invoking callbacks. A handler can also be set per-callback.
 
-### Migration to version 2.2.0
+### Migration to version 2.2
 
-Version 2.2.0 breaks some API known from version 2.1.1.
+Version 2.2 breaks some API known from version 2.1.1.
 Check out [migration guide](MIGRATION.md).
 
 ## Importing
@@ -64,19 +64,19 @@ The library may be found on jcenter and Maven Central repository.
 Add it to your project by adding the following dependency:
 
 ```grovy
-implementation 'no.nordicsemi.android:ble:2.2.0'
+implementation 'no.nordicsemi.android:ble:2.2.1'
 ```
 The last version not migrated to AndroidX is 2.0.5.
 
 To import the BLE library with set of parsers for common Bluetooth SIG characteristics, use:
 ```grovy
-implementation 'no.nordicsemi.android:ble-common:2.2.0'
+implementation 'no.nordicsemi.android:ble-common:2.2.1'
 ```
 For more information, read [this](BLE-COMMON.md).
 
 An extension for easier integration with `LiveData` is available after adding:
 ```grovy
-implementation 'no.nordicsemi.android:ble-livedata:2.2.0'
+implementation 'no.nordicsemi.android:ble-livedata:2.2.1'
 ```
 This extension adds `ObservableBleManager` with `state` and `bondingState` properties, which 
 notify about connection and bond state using `androidx.lifecycle.LiveData`.
@@ -302,7 +302,7 @@ class MyRepo implements ConnectionObserver {
 
 #### Adding GATT Server support
 
-Starting from version 2.2.0 you may now define and use the GATT server in the BLE Library.
+Starting from version 2.2 you may now define and use the GATT server in the BLE Library.
 
 First, override a `BleServerManager` class and override `initializeServer()` method. Some helper
 methods, like `characteristic(...)`, `descriptor(...)` and their shared counterparts were created 
@@ -429,12 +429,9 @@ Find the simple example here [Android nRF Blinky](https://github.com/NordicSemic
 For an example how to use it from an Activity or a Service, check the base Activity and Service 
 classes in [nRF Toolbox](https://github.com/NordicSemiconductor/Android-nRF-Toolbox/tree/master/app/src/main/java/no/nordicsemi/android/nrftoolbox/profile).
 
-*Note:*
-nRF Toolbox has not yet been migrated to BLE Library v.2.2.0.
-
 ## Version 1.x
 
-The BLE library v 1.x is no longer supported. Please migrate to 2.x for bug fixing releases.
+The BLE library v 1.x is no longer supported. Please migrate to 2.2+ for bug fixing releases.
 Find it on [version/1x branch](https://github.com/NordicSemiconductor/Android-BLE-Library/tree/version/1x).
 
 Migration guide is available [here](MIGRATION.md).

--- a/ble/src/main/java/no/nordicsemi/android/ble/BleManager.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/BleManager.java
@@ -574,11 +574,46 @@ public abstract class BleManager implements ILogger {
 	 * <p>
 	 * The returned request must be either enqueued using {@link Request#enqueue()} for
 	 * asynchronous use, or awaited using await() in synchronous execution.
+	 * <p>
+	 * <b>Important:</b> This request does NOT guarantee that the link will be encrypted.
+	 * If the bond information is present on the phone, but was removed from the peripheral
+	 * (or another peripheral is pretending to be the one) this request will succeed, as it
+	 * immediately returns if the bond information is present on the Android client.
+	 * To make sure no sensitive information is stolen, protect your characteristics and/or
+	 * descriptors by assigning them security level. Also, clearly inform user that a device
+	 * is being bonded to avoid MITM.
 	 *
 	 * @return The request.
+	 * @deprecated Use {@link #createBondInsecure()} instead. Deprecated in 2.2.1.
 	 */
+	@Deprecated
 	@NonNull
 	protected Request createBond() {
+		return createBondInsecure();
+	}
+
+	/**
+	 * Returns a request to create bond with the device. The device must be first set using
+	 * {@link #connect(BluetoothDevice)} which will try to connect to the device.
+	 * If you need to pair with a device before connecting to it you may do it without
+	 * the use of BleManager object and connect after bond is established.
+	 * <p>
+	 * The returned request must be either enqueued using {@link Request#enqueue()} for
+	 * asynchronous use, or awaited using await() in synchronous execution.
+	 * <p>
+	 * <b>Important:</b> This request does NOT guarantee that the link will be encrypted.
+	 * If the bond information is present on the phone, but was removed from the peripheral
+	 * (or another peripheral is pretending to be the one) this request will succeed, as it
+	 * immediately returns if the bond information is present on the Android client.
+	 * To make sure no sensitive information is stolen, protect your characteristics and/or
+	 * descriptors by assigning them security level. Also, clearly inform user which device
+	 * is being bonded to avoid MITM.
+	 *
+	 * @return The request.
+	 * @since 2.2.1
+	 */
+	@NonNull
+	protected Request createBondInsecure() {
 		return Request.createBond().setRequestHandler(requestHandler);
 	}
 

--- a/ble/src/main/java/no/nordicsemi/android/ble/BleManagerHandler.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/BleManagerHandler.java
@@ -3122,13 +3122,12 @@ abstract class BleManagerHandler extends RequestHandler {
 				final Request r = request;
 				result = internalRefreshDeviceCache();
 				if (result) {
-					final BluetoothDevice device = bluetoothDevice;
 					postDelayed(() -> {
 						log(Log.INFO, "Cache refreshed");
-						r.notifySuccess(device);
+						r.notifySuccess(bluetoothDevice);
 						this.request = null;
 						if (awaitingRequest != null) {
-							awaitingRequest.notifyFail(device, FailCallback.REASON_NULL_ATTRIBUTE);
+							awaitingRequest.notifyFail(bluetoothDevice, FailCallback.REASON_NULL_ATTRIBUTE);
 							awaitingRequest = null;
 						}
 						taskQueue.clear();
@@ -3146,16 +3145,13 @@ abstract class BleManagerHandler extends RequestHandler {
 				break;
 			}
 			case SLEEP: {
-				final BluetoothDevice device = bluetoothDevice;
-				if (device != null) {
-					final SleepRequest sr = (SleepRequest) request;
-					log(Log.DEBUG, "sleep(" + sr.getDelay() + ")");
-					postDelayed(() -> {
-						sr.notifySuccess(device);
-						nextRequest(true);
-					}, sr.getDelay());
-					result = true;
-				}
+				final SleepRequest sr = (SleepRequest) request;
+				log(Log.DEBUG, "sleep(" + sr.getDelay() + ")");
+				postDelayed(() -> {
+					sr.notifySuccess(bluetoothDevice);
+					nextRequest(true);
+				}, sr.getDelay());
+				result = true;
 				break;
 			}
 			case WAIT_FOR_NOTIFICATION:

--- a/ble/src/main/java/no/nordicsemi/android/ble/RequestHandler.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/RequestHandler.java
@@ -7,17 +7,12 @@ abstract class RequestHandler implements CallbackHandler {
 	 * Enqueues the given request at the end of the the init or task queue, depending
 	 * on whether the initialization is in progress, or not.
 	 *
-	 * @param request the request to be added.
-	 */
-	abstract void enqueue(@NonNull final Request request);
-
-	/**
-	 * Enqueues the given request at the front of the the init or task queue, depending
-	 * on whether the initialization is in progress, or not.
+	 * This method will automatically try to execute the next request (not necessarily the
+	 * enqueued one).
 	 *
 	 * @param request the request to be added.
 	 */
-	abstract void enqueueFirst(@NonNull final Request request);
+	abstract void enqueue(@NonNull final Request request);
 
 	/**
 	 * Removes all enqueued requests from the queue.

--- a/ble/src/main/java/no/nordicsemi/android/ble/SimpleRequest.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/SimpleRequest.java
@@ -28,6 +28,8 @@ import android.bluetooth.BluetoothGattDescriptor;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+
+import no.nordicsemi.android.ble.callback.BeforeCallback;
 import no.nordicsemi.android.ble.callback.FailCallback;
 import no.nordicsemi.android.ble.callback.SuccessCallback;
 import no.nordicsemi.android.ble.exception.BluetoothDisabledException;
@@ -58,8 +60,8 @@ public class SimpleRequest extends Request {
 	/**
 	 * Synchronously waits until the request is done.
 	 * <p>
-	 * Callbacks set using {@link #done(SuccessCallback)} and {@link #fail(FailCallback)}
-	 * will be ignored.
+	 * Callbacks set using {@link #before(BeforeCallback)}, {@link #done(SuccessCallback)} and
+	 * {@link #fail(FailCallback)} will be ignored.
 	 * <p>
 	 * This method may not be called from the main (UI) thread.
 	 *
@@ -77,11 +79,13 @@ public class SimpleRequest extends Request {
 			BluetoothDisabledException, InvalidRequestException {
 		assertNotMainThread();
 
+		final BeforeCallback bc = beforeCallback;
 		final SuccessCallback sc = successCallback;
 		final FailCallback fc = failCallback;
 		try {
 			syncLock.close();
 			final RequestCallback callback = new RequestCallback();
+			beforeCallback = null;
 			done(callback).fail(callback).invalid(callback).enqueue();
 
 			syncLock.block();
@@ -98,6 +102,7 @@ public class SimpleRequest extends Request {
 				throw new RequestFailedException(this, callback.status);
 			}
 		} finally {
+			beforeCallback = bc;
 			successCallback = sc;
 			failCallback = fc;
 		}

--- a/ble/src/main/java/no/nordicsemi/android/ble/SimpleValueRequest.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/SimpleValueRequest.java
@@ -27,6 +27,8 @@ import android.bluetooth.BluetoothGattDescriptor;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+
+import no.nordicsemi.android.ble.callback.BeforeCallback;
 import no.nordicsemi.android.ble.callback.FailCallback;
 import no.nordicsemi.android.ble.callback.SuccessCallback;
 import no.nordicsemi.android.ble.exception.BluetoothDisabledException;
@@ -72,8 +74,8 @@ public abstract class SimpleValueRequest<T> extends SimpleRequest {
 	 * Synchronously waits until the request is done. The given response object will be filled
 	 * with the request response.
 	 * <p>
-	 * Callbacks set using {@link #done(SuccessCallback)} and {@link #fail(FailCallback)} and
-	 * {@link #with(T)} will be ignored.
+	 * Callbacks set using {@link #before(BeforeCallback)}, {@link #done(SuccessCallback)} and
+	 * {@link #fail(FailCallback)} will be ignored.
 	 * <p>
 	 * This method may not be called from the main (UI) thread.
 	 *
@@ -109,8 +111,8 @@ public abstract class SimpleValueRequest<T> extends SimpleRequest {
 	/**
 	 * Synchronously waits until the request is done.
 	 * <p>
-	 * Callbacks set using {@link #done(SuccessCallback)} and {@link #fail(FailCallback)} and
-	 * {@link #with(T)} will be ignored.
+	 * Callbacks set using {@link #before(BeforeCallback)}, {@link #done(SuccessCallback)} and
+	 * {@link #fail(FailCallback)} will be ignored.
 	 * <p>
 	 * This method may not be called from the main (UI) thread.
 	 *

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.0.0'
-        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4'
+        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.5'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.6.3'
+        classpath 'com.android.tools.build:gradle:4.0.0'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,7 +16,7 @@
 # org.gradle.parallel=true
 android.useAndroidX=true
 
-VERSION_NAME=2.2.0
+VERSION_NAME=2.2.1
 GROUP=no.nordicsemi.android
 
 POM_DESCRIPTION=Bluetooth Low Energy library for Android

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Mar 10 12:22:34 CET 2020
+#Tue Jun 09 10:19:34 CEST 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip


### PR DESCRIPTION
This version introduces the following changes and bug fixes:
* `split()` method fixed when used in write request inside atomic queue or as trigger in `waitForNotification` or `waitForIndication` (#200).
* `readRssi()` takes now at most 1 second and times out if no response is received. This may be an issue with connection longer intervals (#114). 
* `createBond()` is now deprecated and was renamed to `createBondInsecure()` (#208). 
* `before(...)` callback is not called before a request that is executed synchronously, unless the request is put into an atomic queue.

Other improvements:
* Migration to Android Studio 4 and Gradle 6.1.1.