### PR TITLE
Executing init queue fixed

### DIFF
--- a/ble/src/main/java/no/nordicsemi/android/ble/BleManagerHandler.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/BleManagerHandler.java
@@ -3185,7 +3185,9 @@ abstract class BleManagerHandler extends RequestHandler {
 									FailCallback.REASON_BLUETOOTH_DISABLED);
 			awaitingRequest = null;
 			connectionPriorityOperationInProgress = false;
-			nextRequest(true);
+			if (!initInProgress) {
+				nextRequest(true);
+			}
 		}
 	}
 

--- a/ble/src/main/java/no/nordicsemi/android/ble/BleManagerHandler.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/BleManagerHandler.java
@@ -2773,7 +2773,7 @@ abstract class BleManagerHandler extends RequestHandler {
 			operationInProgress = awaitingRequest != null;
 		}
 
-		if (operationInProgress) {
+		if (operationInProgress || initInProgress) {
 			return;
 		}
 		final BluetoothDevice bluetoothDevice = this.bluetoothDevice;
@@ -3185,9 +3185,7 @@ abstract class BleManagerHandler extends RequestHandler {
 									FailCallback.REASON_BLUETOOTH_DISABLED);
 			awaitingRequest = null;
 			connectionPriorityOperationInProgress = false;
-			if (!initInProgress) {
-				nextRequest(true);
-			}
+			nextRequest(true);
 		}
 	}
 


### PR DESCRIPTION
This PR fixes #210 - an issue with 2.2.1, where init queue fails on phones running older Android versions.

On Android 4.3-4 5 and 8-9 the lib tries to enable indications for Service Changed characteristic as a first task in initialization queue. The request is aborted when the devices are not bonded, as not relevant. But the abort was causing next request to be started immediately. This accumulated problems, where the `initQueue` could be nullified before any next request was enqueued, causing NPE. The proposed fix disables executing init queue until initialization isn't set up.