### PR TITLE
Add standalone server support to BleServerManager

### DIFF
--- a/ble/src/main/java/no/nordicsemi/android/ble/BleManager.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/BleManager.java
@@ -26,6 +26,7 @@ import android.bluetooth.BluetoothGatt;
 import android.bluetooth.BluetoothGattCallback;
 import android.bluetooth.BluetoothGattCharacteristic;
 import android.bluetooth.BluetoothGattDescriptor;
+import android.bluetooth.BluetoothGattServer;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
@@ -253,6 +254,10 @@ public abstract class BleManager implements ILogger {
 		requestHandler.useServer(null);
 	}
 
+	final void onServerReady(BluetoothGattServer server) {
+		requestHandler.onServerReady(server);
+	}
+
 	/**
 	 * This method will be called if a remote device requires a non-'just works' pairing.
 	 * See PAIRING_* constants for possible options.
@@ -305,6 +310,18 @@ public abstract class BleManager implements ILogger {
 	// constructor. Those can return the device object even without calling connect(device).
 	public BluetoothDevice getBluetoothDevice() {
 		return requestHandler.getBluetoothDevice();
+	}
+
+	/**
+	 * Sets the Bluetooth device object the Manager is currently connected to. Useful when only
+	 * operating a BluetoothGattServer, since those are connected to,
+	 * not connected via {@link #connect(BluetoothDevice)}.
+	 */
+	@Nullable
+	// This method is not final, as some Managers may be created with BluetoothDevice in a
+	// constructor. Those can return the device object even without calling connect(device).
+	public void setBluetoothDevice(BluetoothDevice bluetoothDevice) {
+		requestHandler.bluetoothDevice = bluetoothDevice;
 	}
 
 	/**

--- a/ble/src/main/java/no/nordicsemi/android/ble/BleServerManager.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/BleServerManager.java
@@ -87,7 +87,7 @@ public abstract class BleServerManager implements ILogger {
 				server.addService(service);
 			} catch (final NoSuchElementException e) {
 				if (serverObserver != null)
-					serverObserver.onServerReady();
+					serverObserver.onServerReady(server);
 			} catch (final Exception e) {
 				close();
 				return false;
@@ -665,7 +665,7 @@ public abstract class BleServerManager implements ILogger {
 				} catch (final Exception e) {
 					log(Log.INFO, "[Server] All services added successfully");
 					if (serverObserver != null)
-						serverObserver.onServerReady();
+						serverObserver.onServerReady(server);
 					serverServices = null;
 				}
 			} else {

--- a/ble/src/main/java/no/nordicsemi/android/ble/observer/ServerObserver.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/observer/ServerObserver.java
@@ -2,6 +2,7 @@ package no.nordicsemi.android.ble.observer;
 
 import android.bluetooth.BluetoothDevice;
 
+import android.bluetooth.BluetoothGattServer;
 import androidx.annotation.NonNull;
 import no.nordicsemi.android.ble.BleServerManager;
 
@@ -10,7 +11,7 @@ public interface ServerObserver {
 	/**
 	 * Called when the server was started and all services have been added successfully.
 	 */
-	void onServerReady();
+	void onServerReady(BluetoothGattServer server);
 
 	/**
 	 * This methods is called whenever a Bluetooth LE device connects or when was already connected


### PR DESCRIPTION
This makes it easier to use BleManager in a purely server role, as described in https://github.com/NordicSemiconductor/Android-BLE-Library/issues/229.