### PR TITLE
Improve the handling of ConnectRequests to bonded devices w/ autoConnect=true

### DIFF
--- a/ble/src/main/java/no/nordicsemi/android/ble/BleManagerHandler.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/BleManagerHandler.java
@@ -1759,6 +1759,13 @@ abstract class BleManagerHandler extends RequestHandler {
 						return;
 					}
 
+					if (connectRequest != null && connectRequest.shouldAutoConnect() && initialConnection
+							&& gatt.getDevice().getBondState() == BluetoothDevice.BOND_BONDED) {
+						log(Log.DEBUG, "autoConnect = false called failed; retrying with autoConnect = true");
+						post(() -> internalConnect(gatt.getDevice(), connectRequest));
+						return;
+					}
+
 					operationInProgress = true; // no more calls are possible
 					taskQueue.clear();
 					initQueue = null;


### PR DESCRIPTION
Like https://github.com/NordicSemiconductor/Android-BLE-Library/issues/226 details, it would be better to enqueue an autoConnect=true connect call if the initial autoConnect=false call fails in cases like the title. This will let this library support connecting to peripherals that happen to not be nearby at app startup with a single connect call.

I tested this by observing the logs of an autoConnect=true request when the peripheral is far away. In that case, this is what happens - https://gist.github.com/usikder/363851c49c574b8cd835463434e5ca23. 