### PR TITLE
Update connectGatt version logic to handle bug specifically in API 26

### DIFF
--- a/ble/src/main/java/no/nordicsemi/android/ble/BleManagerHandler.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/BleManagerHandler.java
@@ -564,13 +564,22 @@ abstract class BleManagerHandler extends RequestHandler {
 		postCallback(c -> c.onDeviceConnecting(device));
 		postConnectionStateChange(o -> o.onDeviceConnecting(device));
 		connectionTime = SystemClock.elapsedRealtime();
-		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+		if (Build.VERSION.SDK_INT > Build.VERSION_CODES.O) {
+			// connectRequest will never be null here.
+			final int preferredPhy = connectRequest.getPreferredPhy();
+			log(Log.DEBUG, "gatt = device.connectGatt(autoConnect = false, TRANSPORT_LE, "
+					+ ParserUtils.phyMaskToString(preferredPhy) + ")");
+
+			bluetoothGatt = device.connectGatt(context, false, gattCallback,
+					BluetoothDevice.TRANSPORT_LE, preferredPhy, handler);
+		} else if (Build.VERSION.SDK_INT == Build.VERSION_CODES.O) {
 			// connectRequest will never be null here.
 			final int preferredPhy = connectRequest.getPreferredPhy();
 			log(Log.DEBUG, "gatt = device.connectGatt(autoConnect = false, TRANSPORT_LE, "
 					+ ParserUtils.phyMaskToString(preferredPhy) + ")");
 			// A variant of connectGatt with Handled can't be used here.
 			// Check https://github.com/NordicSemiconductor/Android-BLE-Library/issues/54
+			// This bug specifically occurs in SDK 26 and is fixed in SDK 27
 			bluetoothGatt = device.connectGatt(context, false, gattCallback,
 					BluetoothDevice.TRANSPORT_LE, preferredPhy/*, handler*/);
 		} else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {


### PR DESCRIPTION
Hello @philips77 !

While I was working on faster DFUs I encountered the Android BLE bug where writing to and receiving notifications from the same characteristic asynchronously is totally broken.

In the process of working out a hack fix for the bug for `mcumgr`, I was looking around the internet and the android source and noticed that the issue described in #54 is specific to Android API 26 (8.0.0) which is the exact version I have running on the phone I was testing with. In fact, issue #54 was reported with a samsung s9 which originally shipped with Android 8 installed.

It turns out that the fix for this bug was release in API 27 (8.1.0) which means that we only need to not allow the handler in the call to connectGatt for device running API 26.

The android source bug fix can be found here:
[https://android.googlesource.com/platform/frameworks/base/+/eb6b3da4fc54ca4cfcbb8ee3b927391eed981725%5E%21/#F0](https://android.googlesource.com/platform/frameworks/base/+/eb6b3da4fc54ca4cfcbb8ee3b927391eed981725%5E%21/#F0)

A StackOverflow post with some more info can be found here: [https://stackoverflow.com/a/54182142
](https://stackoverflow.com/a/54182142)

Hope you're doing well.




