### PR TITLE
Reset BleManagerHandler MTU to 23 on disconnect

### DIFF
--- a/ble/src/main/java/no/nordicsemi/android/ble/BleManagerHandler.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/BleManagerHandler.java
@@ -1507,6 +1507,7 @@ abstract class BleManagerHandler extends RequestHandler {
 		serviceDiscoveryRequested = false;
 		deviceNotSupported = false;
 		initInProgress = false;
+		mtu = 23;
 		connectionState = BluetoothGatt.STATE_DISCONNECTED;
 		checkCondition();
 		if (!wasConnected) {


### PR DESCRIPTION
I ran into an issue where the MTU was not being requested when the device disconnected and reconnected with the same `BleManager`.

I'm still not totally familiar with the state management in `BleManagerHandler` so bear with me; from what I can tell, once the MTU is requested successfully, subsequent calls to `requestMtu(int)` don't actually perform the MTU exchange with the device if the same mtu value is requested.

This is ultimately due to the "fast path" logic in `nextRequest()` when handling the `REQUEST_MTU` request type. If the request mtu value is equal to the current (even if the device was disconnected and reconnected) then the actual request will not get sent.

```java
    case REQUEST_MTU: {
        final MtuRequest mr = (MtuRequest) request;
        if (mtu != mr.getRequiredMtu()
                && Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
            result = internalRequestMtu(mr.getRequiredMtu());
        } else {
            result = connected;
            if (result) {
                mr.notifyMtuChanged(bluetoothDevice, mtu);
                mr.notifySuccess(bluetoothDevice);
                nextRequest(true);
                return;
            }
        }
        break;
    }
```

I chose to reset the MTU when the device disconnects, however we could also change the above logic to always send the MTU request, having nearly the same effect. 