### PR TITLE
Adding option to cancel pending connection 

### DIFF
--- a/ble/src/main/java/no/nordicsemi/android/ble/BleManagerHandler.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/BleManagerHandler.java
@@ -1249,20 +1249,24 @@ abstract class BleManagerHandler extends RequestHandler {
 	final void cancelQueue() {
 		taskQueue.clear();
 		initQueue = null;
+		final BluetoothDevice device = this.bluetoothDevice;
+		if (device == null) {
+			return;
+		}
 		if (awaitingRequest != null) {
-			awaitingRequest.notifyFail(bluetoothDevice, FailCallback.REASON_CANCELLED);
+			awaitingRequest.notifyFail(device, FailCallback.REASON_CANCELLED);
 		}
 		if (request != null && awaitingRequest != request) {
-			request.notifyFail(bluetoothDevice, FailCallback.REASON_CANCELLED);
+			request.notifyFail(device, FailCallback.REASON_CANCELLED);
 			request = null;
 		}
 		awaitingRequest = null;
 		if (requestQueue != null) {
-			requestQueue.notifyFail(bluetoothDevice, FailCallback.REASON_CANCELLED);
+			requestQueue.notifyFail(device, FailCallback.REASON_CANCELLED);
 			requestQueue = null;
 		}
 		if (connectRequest != null) {
-			connectRequest.notifyFail(bluetoothDevice, FailCallback.REASON_CANCELLED);
+			connectRequest.notifyFail(device, FailCallback.REASON_CANCELLED);
 			connectRequest = null;
 			internalDisconnect();
 		} else {

--- a/ble/src/main/java/no/nordicsemi/android/ble/ConnectRequest.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/ConnectRequest.java
@@ -221,6 +221,19 @@ public class ConnectRequest extends TimeoutableRequest {
 		return this;
 	}
 
+	/**
+	 * This method cancels the pending connection attempt. All requests enqueued after this one
+	 * will be removed form the queue.
+	 * <p>
+	 * This method does nothing if the connection request has finished successfully, or
+	 * with an error.
+	 */
+	public void cancelPendingConnection() {
+		if (started && !finished) {
+			this.requestHandler.cancelQueue();
+		}
+	}
+
 	@NonNull
 	public BluetoothDevice getDevice() {
 		return device;


### PR DESCRIPTION
This PR closes #251.

**Note:** It was possible to do the same before, using `BleManager#cancelQueue()`. The new method in `ConnectRequest` calls this method. Adding this method makes the API more readable.