### PR TITLE
Adding "then" callback to Requests

### DIFF
--- a/ble/src/main/java/no/nordicsemi/android/ble/ConditionalWaitRequest.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/ConditionalWaitRequest.java
@@ -5,6 +5,7 @@ import android.util.Log;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import no.nordicsemi.android.ble.callback.AfterCallback;
 import no.nordicsemi.android.ble.callback.BeforeCallback;
 import no.nordicsemi.android.ble.callback.FailCallback;
 import no.nordicsemi.android.ble.callback.InvalidRequestCallback;
@@ -73,6 +74,13 @@ public final class ConditionalWaitRequest<T> extends AwaitingRequest<T> implemen
 	@NonNull
 	public ConditionalWaitRequest<T> before(@NonNull final BeforeCallback callback) {
 		super.before(callback);
+		return this;
+	}
+
+	@NonNull
+	@Override
+	public ConditionalWaitRequest<T> then(@NonNull final AfterCallback callback) {
+		super.then(callback);
 		return this;
 	}
 

--- a/ble/src/main/java/no/nordicsemi/android/ble/ConnectRequest.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/ConnectRequest.java
@@ -32,6 +32,7 @@ import android.os.Handler;
 import androidx.annotation.IntRange;
 import androidx.annotation.NonNull;
 import no.nordicsemi.android.ble.annotation.PhyMask;
+import no.nordicsemi.android.ble.callback.AfterCallback;
 import no.nordicsemi.android.ble.callback.BeforeCallback;
 import no.nordicsemi.android.ble.callback.FailCallback;
 import no.nordicsemi.android.ble.callback.InvalidRequestCallback;
@@ -49,7 +50,7 @@ import no.nordicsemi.android.ble.callback.SuccessCallback;
 @SuppressWarnings({"WeakerAccess", "unused"})
 public class ConnectRequest extends TimeoutableRequest {
 	@NonNull
-	private BluetoothDevice device;
+	private final BluetoothDevice device;
 	@PhyMask
 	private int preferredPhy;
 	@IntRange(from = 0)
@@ -124,6 +125,13 @@ public class ConnectRequest extends TimeoutableRequest {
 	@NonNull
 	public ConnectRequest before(@NonNull final BeforeCallback callback) {
 		super.before(callback);
+		return this;
+	}
+
+	@NonNull
+	@Override
+	public ConnectRequest then(@NonNull final AfterCallback callback) {
+		super.then(callback);
 		return this;
 	}
 

--- a/ble/src/main/java/no/nordicsemi/android/ble/ConnectionPriorityRequest.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/ConnectionPriorityRequest.java
@@ -30,6 +30,7 @@ import androidx.annotation.IntRange;
 import androidx.annotation.NonNull;
 import androidx.annotation.RequiresApi;
 import no.nordicsemi.android.ble.annotation.ConnectionPriority;
+import no.nordicsemi.android.ble.callback.AfterCallback;
 import no.nordicsemi.android.ble.callback.BeforeCallback;
 import no.nordicsemi.android.ble.callback.ConnectionPriorityCallback;
 import no.nordicsemi.android.ble.callback.FailCallback;
@@ -119,6 +120,13 @@ public final class ConnectionPriorityRequest extends SimpleValueRequest<Connecti
 	@NonNull
 	public ConnectionPriorityRequest before(@NonNull final BeforeCallback callback) {
 		super.before(callback);
+		return this;
+	}
+
+	@NonNull
+	@Override
+	public ConnectionPriorityRequest then(@NonNull final AfterCallback callback) {
+		super.then(callback);
 		return this;
 	}
 

--- a/ble/src/main/java/no/nordicsemi/android/ble/DisconnectRequest.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/DisconnectRequest.java
@@ -26,6 +26,7 @@ import android.os.Handler;
 
 import androidx.annotation.IntRange;
 import androidx.annotation.NonNull;
+import no.nordicsemi.android.ble.callback.AfterCallback;
 import no.nordicsemi.android.ble.callback.BeforeCallback;
 import no.nordicsemi.android.ble.callback.FailCallback;
 import no.nordicsemi.android.ble.callback.InvalidRequestCallback;
@@ -83,6 +84,13 @@ public class DisconnectRequest extends TimeoutableRequest {
 	@NonNull
 	public DisconnectRequest before(@NonNull final BeforeCallback callback) {
 		super.before(callback);
+		return this;
+	}
+
+	@NonNull
+	@Override
+	public DisconnectRequest then(@NonNull final AfterCallback callback) {
+		super.then(callback);
 		return this;
 	}
 }

--- a/ble/src/main/java/no/nordicsemi/android/ble/MtuRequest.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/MtuRequest.java
@@ -27,6 +27,7 @@ import android.os.Handler;
 
 import androidx.annotation.IntRange;
 import androidx.annotation.NonNull;
+import no.nordicsemi.android.ble.callback.AfterCallback;
 import no.nordicsemi.android.ble.callback.BeforeCallback;
 import no.nordicsemi.android.ble.callback.FailCallback;
 import no.nordicsemi.android.ble.callback.InvalidRequestCallback;
@@ -84,6 +85,13 @@ public final class MtuRequest extends SimpleValueRequest<MtuCallback> implements
 	@NonNull
 	public MtuRequest before(@NonNull final BeforeCallback callback) {
 		super.before(callback);
+		return this;
+	}
+
+	@NonNull
+	@Override
+	public MtuRequest then(@NonNull final AfterCallback callback) {
+		super.then(callback);
 		return this;
 	}
 

--- a/ble/src/main/java/no/nordicsemi/android/ble/PhyRequest.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/PhyRequest.java
@@ -29,6 +29,7 @@ import androidx.annotation.NonNull;
 import no.nordicsemi.android.ble.annotation.PhyMask;
 import no.nordicsemi.android.ble.annotation.PhyOption;
 import no.nordicsemi.android.ble.annotation.PhyValue;
+import no.nordicsemi.android.ble.callback.AfterCallback;
 import no.nordicsemi.android.ble.callback.BeforeCallback;
 import no.nordicsemi.android.ble.callback.FailCallback;
 import no.nordicsemi.android.ble.callback.InvalidRequestCallback;
@@ -135,6 +136,13 @@ public final class PhyRequest extends SimpleValueRequest<PhyCallback> implements
 	@NonNull
 	public PhyRequest before(@NonNull final BeforeCallback callback) {
 		super.before(callback);
+		return this;
+	}
+
+	@NonNull
+	@Override
+	public PhyRequest then(@NonNull final AfterCallback callback) {
+		super.then(callback);
 		return this;
 	}
 

--- a/ble/src/main/java/no/nordicsemi/android/ble/ReadRequest.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/ReadRequest.java
@@ -30,6 +30,7 @@ import android.os.Handler;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import no.nordicsemi.android.ble.callback.AfterCallback;
 import no.nordicsemi.android.ble.callback.BeforeCallback;
 import no.nordicsemi.android.ble.callback.DataReceivedCallback;
 import no.nordicsemi.android.ble.callback.FailCallback;
@@ -106,6 +107,13 @@ public final class ReadRequest extends SimpleValueRequest<DataReceivedCallback> 
 	@NonNull
 	public ReadRequest before(@NonNull final BeforeCallback callback) {
 		super.before(callback);
+		return this;
+	}
+
+	@NonNull
+	@Override
+	public ReadRequest then(@NonNull final AfterCallback callback) {
+		super.then(callback);
 		return this;
 	}
 

--- a/ble/src/main/java/no/nordicsemi/android/ble/ReadRssiRequest.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/ReadRssiRequest.java
@@ -27,6 +27,7 @@ import android.os.Handler;
 
 import androidx.annotation.IntRange;
 import androidx.annotation.NonNull;
+import no.nordicsemi.android.ble.callback.AfterCallback;
 import no.nordicsemi.android.ble.callback.BeforeCallback;
 import no.nordicsemi.android.ble.callback.FailCallback;
 import no.nordicsemi.android.ble.callback.InvalidRequestCallback;
@@ -78,6 +79,13 @@ public final class ReadRssiRequest extends SimpleValueRequest<RssiCallback> impl
 	@NonNull
 	public ReadRssiRequest before(@NonNull final BeforeCallback callback) {
 		super.before(callback);
+		return this;
+	}
+
+	@NonNull
+	@Override
+	public ReadRssiRequest then(@NonNull final AfterCallback callback) {
+		super.then(callback);
 		return this;
 	}
 

--- a/ble/src/main/java/no/nordicsemi/android/ble/ReliableWriteRequest.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/ReliableWriteRequest.java
@@ -25,6 +25,7 @@ package no.nordicsemi.android.ble;
 import android.os.Handler;
 
 import androidx.annotation.NonNull;
+import no.nordicsemi.android.ble.callback.AfterCallback;
 import no.nordicsemi.android.ble.callback.BeforeCallback;
 import no.nordicsemi.android.ble.callback.FailCallback;
 import no.nordicsemi.android.ble.callback.InvalidRequestCallback;
@@ -75,6 +76,13 @@ public final class ReliableWriteRequest extends RequestQueue {
 	@NonNull
 	public ReliableWriteRequest before(@NonNull final BeforeCallback callback) {
 		super.before(callback);
+		return this;
+	}
+
+	@NonNull
+	@Override
+	public ReliableWriteRequest then(@NonNull final AfterCallback callback) {
+		super.then(callback);
 		return this;
 	}
 

--- a/ble/src/main/java/no/nordicsemi/android/ble/RequestQueue.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/RequestQueue.java
@@ -32,6 +32,7 @@ import androidx.annotation.Nullable;
 import java.util.Deque;
 import java.util.LinkedList;
 
+import no.nordicsemi.android.ble.callback.AfterCallback;
 import no.nordicsemi.android.ble.callback.BeforeCallback;
 import no.nordicsemi.android.ble.callback.FailCallback;
 import no.nordicsemi.android.ble.callback.InvalidRequestCallback;
@@ -93,6 +94,13 @@ public class RequestQueue extends Request {
 	@NonNull
 	public RequestQueue before(@NonNull final BeforeCallback callback) {
 		super.before(callback);
+		return this;
+	}
+
+	@NonNull
+	@Override
+	public RequestQueue then(@NonNull final AfterCallback callback) {
+		super.then(callback);
 		return this;
 	}
 

--- a/ble/src/main/java/no/nordicsemi/android/ble/SetValueRequest.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/SetValueRequest.java
@@ -7,6 +7,7 @@ import android.os.Handler;
 import androidx.annotation.IntRange;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import no.nordicsemi.android.ble.callback.AfterCallback;
 import no.nordicsemi.android.ble.callback.BeforeCallback;
 import no.nordicsemi.android.ble.callback.FailCallback;
 import no.nordicsemi.android.ble.callback.InvalidRequestCallback;
@@ -70,6 +71,13 @@ public final class SetValueRequest extends SimpleRequest {
 	@NonNull
 	public SetValueRequest before(@NonNull final BeforeCallback callback) {
 		super.before(callback);
+		return this;
+	}
+
+	@NonNull
+	@Override
+	public SetValueRequest then(@NonNull final AfterCallback callback) {
+		super.then(callback);
 		return this;
 	}
 

--- a/ble/src/main/java/no/nordicsemi/android/ble/SleepRequest.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/SleepRequest.java
@@ -26,6 +26,7 @@ import android.os.Handler;
 
 import androidx.annotation.IntRange;
 import androidx.annotation.NonNull;
+import no.nordicsemi.android.ble.callback.AfterCallback;
 import no.nordicsemi.android.ble.callback.BeforeCallback;
 import no.nordicsemi.android.ble.callback.FailCallback;
 import no.nordicsemi.android.ble.callback.InvalidRequestCallback;
@@ -78,6 +79,13 @@ public final class SleepRequest extends SimpleRequest implements Operation {
 	@Override
 	public SleepRequest before(@NonNull final BeforeCallback callback) {
 		super.before(callback);
+		return this;
+	}
+
+	@NonNull
+	@Override
+	public SleepRequest then(@NonNull final AfterCallback callback) {
+		super.then(callback);
 		return this;
 	}
 

--- a/ble/src/main/java/no/nordicsemi/android/ble/WaitForReadRequest.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/WaitForReadRequest.java
@@ -8,6 +8,7 @@ import android.os.Handler;
 import androidx.annotation.IntRange;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import no.nordicsemi.android.ble.callback.AfterCallback;
 import no.nordicsemi.android.ble.callback.BeforeCallback;
 import no.nordicsemi.android.ble.callback.DataSentCallback;
 import no.nordicsemi.android.ble.callback.FailCallback;
@@ -103,6 +104,13 @@ public final class WaitForReadRequest extends AwaitingRequest<DataSentCallback> 
 	@NonNull
 	public WaitForReadRequest before(@NonNull final BeforeCallback callback) {
 		super.before(callback);
+		return this;
+	}
+
+	@NonNull
+	@Override
+	public WaitForReadRequest then(@NonNull final AfterCallback callback) {
+		super.then(callback);
 		return this;
 	}
 

--- a/ble/src/main/java/no/nordicsemi/android/ble/WaitForValueChangedRequest.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/WaitForValueChangedRequest.java
@@ -30,6 +30,7 @@ import android.os.Handler;
 import androidx.annotation.IntRange;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import no.nordicsemi.android.ble.callback.AfterCallback;
 import no.nordicsemi.android.ble.callback.BeforeCallback;
 import no.nordicsemi.android.ble.callback.DataReceivedCallback;
 import no.nordicsemi.android.ble.callback.FailCallback;
@@ -113,6 +114,13 @@ public final class WaitForValueChangedRequest extends AwaitingRequest<DataReceiv
 	@NonNull
 	public WaitForValueChangedRequest before(@NonNull final BeforeCallback callback) {
 		super.before(callback);
+		return this;
+	}
+
+	@NonNull
+	@Override
+	public WaitForValueChangedRequest then(@NonNull final AfterCallback callback) {
+		super.then(callback);
 		return this;
 	}
 

--- a/ble/src/main/java/no/nordicsemi/android/ble/WriteRequest.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/WriteRequest.java
@@ -34,6 +34,7 @@ import androidx.annotation.IntRange;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import no.nordicsemi.android.ble.annotation.WriteType;
+import no.nordicsemi.android.ble.callback.AfterCallback;
 import no.nordicsemi.android.ble.callback.BeforeCallback;
 import no.nordicsemi.android.ble.callback.DataSentCallback;
 import no.nordicsemi.android.ble.callback.FailCallback;
@@ -134,6 +135,13 @@ public final class WriteRequest extends SimpleValueRequest<DataSentCallback> imp
 	@NonNull
 	public WriteRequest before(@NonNull final BeforeCallback callback) {
 		super.before(callback);
+		return this;
+	}
+
+	@NonNull
+	@Override
+	public WriteRequest then(@NonNull final AfterCallback callback) {
+		super.then(callback);
 		return this;
 	}
 

--- a/ble/src/main/java/no/nordicsemi/android/ble/callback/AfterCallback.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/callback/AfterCallback.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2018, Nordic Semiconductor
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this
+ * software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+ * USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package no.nordicsemi.android.ble.callback;
+
+import android.bluetooth.BluetoothDevice;
+
+import androidx.annotation.NonNull;
+
+@FunctionalInterface
+public interface AfterCallback {
+
+	/**
+	 * A callback invoked when the request has been precessed. It is called no matter the result
+	 * of the request was.
+	 *
+	 * @param device the target device.
+	 */
+	void onRequestFinished(@NonNull final BluetoothDevice device);
+}

--- a/ble/src/main/java/no/nordicsemi/android/ble/callback/BeforeCallback.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/callback/BeforeCallback.java
@@ -26,6 +26,7 @@ import android.bluetooth.BluetoothDevice;
 
 import androidx.annotation.NonNull;
 
+@FunctionalInterface
 public interface BeforeCallback {
 
 	/**

--- a/ble/src/main/java/no/nordicsemi/android/ble/callback/ConnectionPriorityCallback.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/callback/ConnectionPriorityCallback.java
@@ -46,6 +46,7 @@ import androidx.annotation.NonNull;
  * Android Oreo added a hidden callback to {@link android.bluetooth.BluetoothGattCallback}
  * notifying about connection parameters change. Those values will be reported with this callback.
  */
+@FunctionalInterface
 public interface ConnectionPriorityCallback {
 
 	/**

--- a/ble/src/main/java/no/nordicsemi/android/ble/callback/DataReceivedCallback.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/callback/DataReceivedCallback.java
@@ -28,6 +28,7 @@ import androidx.annotation.NonNull;
 import no.nordicsemi.android.ble.data.Data;
 import no.nordicsemi.android.ble.data.DataMerger;
 
+@FunctionalInterface
 public interface DataReceivedCallback {
 
 	/**

--- a/ble/src/main/java/no/nordicsemi/android/ble/callback/DataSentCallback.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/callback/DataSentCallback.java
@@ -28,6 +28,7 @@ import androidx.annotation.NonNull;
 import no.nordicsemi.android.ble.data.Data;
 import no.nordicsemi.android.ble.data.DataSplitter;
 
+@FunctionalInterface
 public interface DataSentCallback {
 
 	/**

--- a/ble/src/main/java/no/nordicsemi/android/ble/callback/FailCallback.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/callback/FailCallback.java
@@ -26,6 +26,7 @@ import android.bluetooth.BluetoothDevice;
 
 import androidx.annotation.NonNull;
 
+@FunctionalInterface
 public interface FailCallback {
 	int REASON_DEVICE_DISCONNECTED = -1;
 	int REASON_DEVICE_NOT_SUPPORTED = -2;

--- a/ble/src/main/java/no/nordicsemi/android/ble/callback/InvalidRequestCallback.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/callback/InvalidRequestCallback.java
@@ -22,6 +22,7 @@
 
 package no.nordicsemi.android.ble.callback;
 
+@FunctionalInterface
 public interface InvalidRequestCallback {
 
 	/**

--- a/ble/src/main/java/no/nordicsemi/android/ble/callback/MtuCallback.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/callback/MtuCallback.java
@@ -27,6 +27,7 @@ import android.bluetooth.BluetoothDevice;
 import androidx.annotation.IntRange;
 import androidx.annotation.NonNull;
 
+@FunctionalInterface
 public interface MtuCallback {
 
 	/**

--- a/ble/src/main/java/no/nordicsemi/android/ble/callback/PhyCallback.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/callback/PhyCallback.java
@@ -27,7 +27,7 @@ import android.bluetooth.BluetoothDevice;
 import androidx.annotation.NonNull;
 import no.nordicsemi.android.ble.annotation.PhyValue;
 
-@SuppressWarnings("unused")
+@FunctionalInterface
 public interface PhyCallback {
 	/**
 	 * Bluetooth LE 1M PHY. Used to refer to LE 1M Physical Channel for advertising, scanning or

--- a/ble/src/main/java/no/nordicsemi/android/ble/callback/ReadProgressCallback.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/callback/ReadProgressCallback.java
@@ -29,6 +29,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import no.nordicsemi.android.ble.data.DataMerger;
 
+@FunctionalInterface
 public interface ReadProgressCallback {
 
 	/**

--- a/ble/src/main/java/no/nordicsemi/android/ble/callback/RssiCallback.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/callback/RssiCallback.java
@@ -27,6 +27,7 @@ import android.bluetooth.BluetoothDevice;
 import androidx.annotation.IntRange;
 import androidx.annotation.NonNull;
 
+@FunctionalInterface
 public interface RssiCallback {
 
 	/**

--- a/ble/src/main/java/no/nordicsemi/android/ble/callback/SuccessCallback.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/callback/SuccessCallback.java
@@ -26,6 +26,7 @@ import android.bluetooth.BluetoothDevice;
 
 import androidx.annotation.NonNull;
 
+@FunctionalInterface
 public interface SuccessCallback {
 
 	/**

--- a/ble/src/main/java/no/nordicsemi/android/ble/callback/WriteProgressCallback.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/callback/WriteProgressCallback.java
@@ -29,6 +29,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import no.nordicsemi.android.ble.data.DataSplitter;
 
+@FunctionalInterface
 public interface WriteProgressCallback {
 
 	/**


### PR DESCRIPTION
This PR adds `then(BluetoothDevice)` callback to `Reqeust` class. The callback will be invoked when the request has been processed no matter the result. However, if `BluetoothDevice` was not set, `invalid()` callback will be called instead.