### PR TITLE
init descriptor value if not contains key

### DIFF
--- a/ble/src/main/java/no/nordicsemi/android/ble/BleManagerHandler.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/BleManagerHandler.java
@@ -1915,7 +1915,8 @@ abstract class BleManagerHandler extends RequestHandler {
 										if (!serverManager.isShared(descriptor)) {
 											if (descriptorValues == null)
 												descriptorValues = new HashMap<>();
-											descriptorValues.put(descriptor, descriptor.getValue());
+											if (!descriptorValues.containsKey(descriptor))
+												descriptorValues.put(descriptor, descriptor.getValue());
 										}
 									}
 								}


### PR DESCRIPTION
Run as GATT Server that has notify characteristic.
After connected from central, the sequences from GATT client are service discovery and subscribe notify characteristic.
However, the sequences from some GATT client are like this.

1. service discovery
2. subscribe notify characteristic
3. service discovery again

I don't know why some GATT client do service discovery again.
That may be GATT client bug.

But, I want to prevent initialize descriptor values from 2nd service discovery.
In other words, I want to keep characteristic subscribe status.