### PR TITLE
Added support for passkey on pairing request

### DIFF
--- a/ble/src/main/java/no/nordicsemi/android/ble/BleManager.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/BleManager.java
@@ -137,10 +137,11 @@ public abstract class BleManager implements ILogger {
 
 			// String values are used as the constants are not available for Android 4.3.
 			final int variant = intent.getIntExtra("android.bluetooth.device.extra.PAIRING_VARIANT"/*BluetoothDevice.EXTRA_PAIRING_VARIANT*/, 0);
+			final int key = intent.getIntExtra("android.bluetooth.device.extra.PAIRING_KEY"/*BluetoothDevice.PAIRING_KEY*/, -1);
 			log(Log.DEBUG, "[Broadcast] Action received: android.bluetooth.device.action.PAIRING_REQUEST"/*BluetoothDevice.ACTION_PAIRING_REQUEST*/ +
-					", pairing variant: " + ParserUtils.pairingVariantToString(variant) + " (" + variant + ")");
+					", pairing variant: " + ParserUtils.pairingVariantToString(variant) + " (" + variant + "); key: "+key);
 
-			onPairingRequestReceived(device, variant);
+			onPairingRequestReceived(device, variant, key);
 		}
 	};
 
@@ -261,9 +262,11 @@ public abstract class BleManager implements ILogger {
 	 *
 	 * @param device  the device.
 	 * @param variant pairing variant.
+	 * @param key     pairing passkey, if supported by variant. -1 otherwise
 	 */
 	protected void onPairingRequestReceived(@NonNull final BluetoothDevice device,
-											@PairingVariant final int variant) {
+											@PairingVariant final int variant
+											final int key) {
 		// The API below is available for Android 4.4 or newer.
 
 		// An app may set the PIN here or set pairing confirmation (depending on the variant) using:


### PR DESCRIPTION
An additional int-extra ("android.bluetooth.device.extra.PAIRING_KEY") is passes with the pairing request if PAIRING_VARIANT has value PAIRING_VARIANT_PASSKEY_CONFIRMATION (0x00000002). I this case the passed key has to be displayed for the user who is now able to compare and confirm the paring.

see https://developer.android.com/reference/android/bluetooth/BluetoothDevice#EXTRA_PAIRING_KEY