### PR TITLE
Skipping processing requests when MTU changed before services were discovered

### DIFF
--- a/ble/src/main/java/no/nordicsemi/android/ble/BleManagerHandler.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/BleManagerHandler.java
@@ -2355,7 +2355,14 @@ abstract class BleManagerHandler extends RequestHandler {
 				onError(gatt.getDevice(), ERROR_MTU_REQUEST, status);
 			}
 			checkCondition();
-			nextRequest(true);
+			// If the device was already connected using another client (BluetoothGatt object),
+			// which had requested MTU change, just after connection this new MTU may be reported
+			// to this client. This happens even before service discovery, effectively reporting
+			// the device ready (as init queue is still null at this time).
+			// This check should help.
+			if (servicesDiscovered) {
+				nextRequest(true);
+			}
 		}
 
 		/**


### PR DESCRIPTION
This PR fixes an issue reported here: https://github.com/JuulLabs-OSS/mcumgr-android/issues/93

When a different client had been connected to the device which requested MTU change, just after a new client connects it receives `onMtuChanged` with the value requested by the previous client. This happened even before the new client initiated service discovery, so initialization queue was still `null`. Calling `nextRequest` in such case was effectively setting the device ready.
The new check ensures that `nextRequest` is not called before services were discovered, which should help solve the problem.