### PR TITLE
More ktx extensions

### DIFF
--- a/ble-ktx/src/main/java/no/nordicsemi/android/ble/ktx/BleManagerExt.kt
+++ b/ble-ktx/src/main/java/no/nordicsemi/android/ble/ktx/BleManagerExt.kt
@@ -39,15 +39,13 @@ val BleManager.bondingState: BondState
 /**
  * Returns the connection state as hot state flow.
  */
-fun BleManager.stateAsFlow() =
-    MutableStateFlow(state)
+fun BleManager.stateAsFlow() = MutableStateFlow(state)
         .apply { setConnectionObserver(observeAsFlow(this)) }
 
 /**
  * Returns the bonding state as hot state flow.
  */
-fun BleManager.bondingStateAsFlow() =
-    MutableStateFlow(bondingState)
+fun BleManager.bondingStateAsFlow() = MutableStateFlow(bondingState)
         .apply { setBondingObserver(observeAsFlow(this)) }
 
 // ------------------------------------ Implementation ------------------------------------

--- a/ble-ktx/src/main/java/no/nordicsemi/android/ble/ktx/RequestSuspend.kt
+++ b/ble-ktx/src/main/java/no/nordicsemi/android/ble/ktx/RequestSuspend.kt
@@ -1,13 +1,14 @@
 package no.nordicsemi.android.ble.ktx
 
+import android.bluetooth.BluetoothDevice
 import kotlinx.coroutines.suspendCancellableCoroutine
 import no.nordicsemi.android.ble.*
 import no.nordicsemi.android.ble.callback.FailCallback
+import no.nordicsemi.android.ble.callback.profile.ProfileReadResponse
 import no.nordicsemi.android.ble.data.Data
-import no.nordicsemi.android.ble.exception.BluetoothDisabledException
-import no.nordicsemi.android.ble.exception.DeviceDisconnectedException
-import no.nordicsemi.android.ble.exception.InvalidRequestException
-import no.nordicsemi.android.ble.exception.RequestFailedException
+import no.nordicsemi.android.ble.exception.*
+import no.nordicsemi.android.ble.response.ReadResponse
+import no.nordicsemi.android.ble.response.WriteResponse
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 
@@ -39,6 +40,35 @@ suspend fun WriteRequest.suspend(): Data {
 }
 
 /**
+ * Suspends the coroutine until the data have been written.
+ * The data sent is parsed to the given type.
+ *
+ * Usage:
+ *
+ *     // Assuming AlertLevelRequest is a class similar to AlertDataResponse from ble-common
+ *     // module, but extends WriteResponse interface instead of ProfileReadResponse.
+ *     val result: AlertLevelRequest = writeCharacteristic(
+ *             alertLevelCharacteristic,
+ *             AlertLevelData.highAlert(),
+ *             BluetoothGattCharacteristic.WRITE_TYPE_NO_RESPONSE
+ *         ).suspendForResponse()
+ *
+ * @return The data written parsed to required type.
+ */
+@Throws(
+	BluetoothDisabledException::class,
+	DeviceDisconnectedException::class,
+	RequestFailedException::class,
+	InvalidRequestException::class
+)
+suspend inline fun <reified T: WriteResponse> WriteRequest.suspendForResponse(): T {
+	var device: BluetoothDevice? = null
+	then { d -> device = d }.suspend().let {
+		return T::class.java.newInstance().apply { onDataSent(device!!, it) }
+	}
+}
+
+/**
  * Suspends the coroutine until the data have been read.
  * @return The data read.
  */
@@ -52,6 +82,54 @@ suspend fun ReadRequest.suspend(): Data {
 	var result: Data? = null
 	with { _, data -> result = data }.suspendCancellable()
 	return result!!
+}
+
+/**
+ * Suspends the coroutine until the data have been read.
+ * The data read is parsed to the given type.
+ *
+ * Usage:
+ *
+ *     val result: AlertLevelResponse = readCharacteristic(alertLevelCharacteristic)
+ *         .suspendForResponse()
+ *
+ * @return The data read parsed to required type.
+ */
+@Throws(
+	BluetoothDisabledException::class,
+	DeviceDisconnectedException::class,
+	RequestFailedException::class,
+	InvalidRequestException::class
+)
+suspend inline fun <reified T: ReadResponse> ReadRequest.suspendForResponse(): T {
+	var device: BluetoothDevice? = null
+	then { d -> device = d }.suspend().let {
+		return T::class.java.newInstance().apply { onDataReceived(device!!, it) }
+	}
+}
+
+/**
+ * Suspends the coroutine until the data have been read.
+ * The data read is parsed to the given type.
+ * If the received data are not valid, an [InvalidDataException] is thrown.
+ *
+ * Usage:
+ *
+ *     val result: AlertLevelResponse = readCharacteristic(alertLevelCharacteristic)
+ *         .suspendForValidResponse()
+ *
+ * @return The data read parsed to required type.
+ */
+@Throws(
+	BluetoothDisabledException::class,
+	DeviceDisconnectedException::class,
+	RequestFailedException::class,
+	InvalidRequestException::class,
+	InvalidDataException::class
+)
+suspend inline fun <reified T: ProfileReadResponse> ReadRequest.suspendForValidResponse(): T {
+	val response = suspendForResponse<T>()
+	return response.takeIf { it.isValid } ?: throw InvalidDataException(response)
 }
 
 /**
@@ -96,7 +174,7 @@ suspend fun MtuRequest.suspend(): Int {
 	RequestFailedException::class,
 	InvalidRequestException::class
 )
-suspend fun PhyRequest.suspend():  Pair<Int, Int> {
+suspend fun PhyRequest.suspend(): Pair<Int, Int> {
 	var result: Pair<Int, Int>? = null
 	with { _, txPhy, rxPhy -> result = txPhy to rxPhy }.suspendCancellable()
 	return result!!
@@ -113,7 +191,7 @@ suspend fun PhyRequest.suspend():  Pair<Int, Int> {
 	InvalidRequestException::class
 )
 suspend fun WaitForValueChangedRequest.suspend(): Data  = suspendCancellableCoroutine { continuation ->	this
-	.with { _, data ->continuation.resume(data) }
+	.with { _, data -> continuation.resume(data) }
 	.invalid { continuation.resumeWithException(InvalidRequestException(this)) }
 	.fail { _, status ->
 		val exception = when (status) {
@@ -128,6 +206,52 @@ suspend fun WaitForValueChangedRequest.suspend(): Data  = suspendCancellableCoro
 
 /**
  * Suspends the coroutine until the value of the attribute has changed.
+ *
+ * Usage:
+ *
+ *     val result: HeartRateMeasurementResponse = waitForNotification(hmrCharacteristic)
+ *         .suspendForResponse()
+ *
+ * @return The new value of the attribute.
+ */
+@Throws(
+	BluetoothDisabledException::class,
+	DeviceDisconnectedException::class,
+	RequestFailedException::class,
+	InvalidRequestException::class
+)
+suspend inline fun <reified T: ReadResponse> WaitForValueChangedRequest.suspendForResponse(): T {
+	var device: BluetoothDevice? = null
+	then { d -> device = d }.suspend().let {
+		return T::class.java.newInstance().apply { onDataReceived(device!!, it) }
+	}
+}
+
+/**
+ * Suspends the coroutine until the value of the attribute has changed and is valid.
+ * If the value is invalid, an [InvalidDataException] is thrown.
+ *
+ * Usage:
+ *
+ *     val result: HeartRateMeasurementResponse = waitForNotification(hmrCharacteristic)
+ *         .suspendForValidResponse()
+ *
+ * @return The new value of the attribute.
+ */
+@Throws(
+	BluetoothDisabledException::class,
+	DeviceDisconnectedException::class,
+	RequestFailedException::class,
+	InvalidRequestException::class,
+	InvalidDataException::class
+)
+suspend inline fun <reified T: ProfileReadResponse> WaitForValueChangedRequest.suspendForValidResponse(): T {
+	val response = suspendForResponse<T>()
+	return response.takeIf { it.isValid } ?: throw InvalidDataException(response)
+}
+
+/**
+ * Suspends the coroutine until the value of the attribute has changed.
  * @return The new value of the attribute.
  */
 @Throws(
@@ -137,7 +261,7 @@ suspend fun WaitForValueChangedRequest.suspend(): Data  = suspendCancellableCoro
 	InvalidRequestException::class
 )
 suspend fun WaitForReadRequest.suspend(): Data  = suspendCancellableCoroutine { continuation ->	this
-	.with { _, data ->continuation.resume(data) }
+	.with { _, data -> continuation.resume(data) }
 	.invalid { continuation.resumeWithException(InvalidRequestException(this)) }
 	.fail { _, status ->
 		val exception = when (status) {
@@ -148,6 +272,31 @@ suspend fun WaitForReadRequest.suspend(): Data  = suspendCancellableCoroutine { 
 		continuation.resumeWithException(exception)
 	}
 	.enqueue()
+}
+
+/**
+ * Suspends the coroutine until the remote device reads the value and the response is sent.
+ *
+ * Usage:
+ *
+ *     // Assuming AlertLevelRequest is a class similar to AlertDataResponse from ble-common
+ *     // module, but extends WriteResponse interface instead of ProfileReadResponse.
+ *     val result: AlertLevelRequest = waitForRead(alertLevelCharacteristic)
+ *         .suspendForResponse()
+ *
+ * @return The new value of the attribute.
+ */
+@Throws(
+	BluetoothDisabledException::class,
+	DeviceDisconnectedException::class,
+	RequestFailedException::class,
+	InvalidRequestException::class
+)
+suspend inline fun <reified T: WriteResponse> WaitForReadRequest.suspendForResponse(): T {
+	var device: BluetoothDevice? = null
+	then { d -> device = d }.suspend().let {
+		return T::class.java.newInstance().apply { onDataSent(device!!, it) }
+	}
 }
 
 private suspend fun Request.suspendCancellable(): Unit = suspendCancellableCoroutine { continuation -> this

--- a/ble-ktx/src/main/java/no/nordicsemi/android/ble/ktx/ValueChangedCallbackExt.kt
+++ b/ble-ktx/src/main/java/no/nordicsemi/android/ble/ktx/ValueChangedCallbackExt.kt
@@ -14,7 +14,7 @@ import no.nordicsemi.android.ble.response.ReadResponse
  *
  * Usage:
  *
- *     val hrmMeasurementsData = enableNotifications(hrmCharacteristic).asFlow()
+ *     val hrmMeasurementsData = setNotificationCallback(hrmCharacteristic).asFlow()  // Flow<Data>
  * @return The flow.
  */
 @ExperimentalCoroutinesApi
@@ -33,7 +33,9 @@ fun ValueChangedCallback.asFlow(): Flow<Data> = callbackFlow {
  *
  * Usage:
  *
- *     val hrmMeasurementsData: Flow<HeartRateMeasurementResponse> = enableNotifications(hrmCharacteristic).asResponseFlow()
+ *     val hrmMeasurementsData: Flow<HeartRateMeasurementResponse> =
+ *         setNotificationCallback(hrmCharacteristic)
+ *             .asResponseFlow()
  * @return The flow.
  */
 @ExperimentalCoroutinesApi
@@ -53,7 +55,9 @@ inline fun <reified T: ReadResponse> ValueChangedCallback.asResponseFlow(): Flow
  *
  * Usage:
  *
- *     val hrmMeasurementsData: Flow<HeartRateMeasurementResponse> = enableNotifications(hrmCharacteristic).asValidResponseFlow()
+ *     val hrmMeasurementsData: Flow<HeartRateMeasurementResponse> =
+ *         setNotificationCallback(hrmCharacteristic)
+ *             .asValidResponseFlow()
  * @return The flow.
  */
 @ExperimentalCoroutinesApi

--- a/ble-ktx/src/main/java/no/nordicsemi/android/ble/ktx/ValueChangedCallbackExt.kt
+++ b/ble-ktx/src/main/java/no/nordicsemi/android/ble/ktx/ValueChangedCallbackExt.kt
@@ -5,16 +5,64 @@ import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
 import no.nordicsemi.android.ble.ValueChangedCallback
+import no.nordicsemi.android.ble.callback.profile.ProfileReadResponse
 import no.nordicsemi.android.ble.data.Data
+import no.nordicsemi.android.ble.response.ReadResponse
 
 /**
  * Represents the value changed callback as a cold flow of bytes.
+ *
+ * Usage:
+ *
+ *     val hrmMeasurementsData = enableNotifications(hrmCharacteristic).asFlow()
  * @return The flow.
  */
 @ExperimentalCoroutinesApi
 fun ValueChangedCallback.asFlow(): Flow<Data> = callbackFlow {
     with { _, data ->
         trySend(data)
+    }
+    awaitClose {
+        // There's no way to unregister the callback from here.
+        with { _, _ -> }
+    }
+}
+
+/**
+ * Represents the value changed callback as a cold flow of responses of returned type.
+ *
+ * Usage:
+ *
+ *     val hrmMeasurementsData: Flow<HeartRateMeasurementResponse> = enableNotifications(hrmCharacteristic).asResponseFlow()
+ * @return The flow.
+ */
+@ExperimentalCoroutinesApi
+inline fun <reified T: ReadResponse> ValueChangedCallback.asResponseFlow(): Flow<T> = callbackFlow {
+    with { device, data ->
+        trySend(T::class.java.newInstance().apply { onDataReceived(device, data) })
+    }
+    awaitClose {
+        // There's no way to unregister the callback from here.
+        with { _, _ -> }
+    }
+}
+
+/**
+ * Represents the value changed callback as a cold flow of responses of returned type.
+ * Invalid values, which could not be parsed to the type, are ignored.
+ *
+ * Usage:
+ *
+ *     val hrmMeasurementsData: Flow<HeartRateMeasurementResponse> = enableNotifications(hrmCharacteristic).asValidResponseFlow()
+ * @return The flow.
+ */
+@ExperimentalCoroutinesApi
+inline fun <reified T: ProfileReadResponse> ValueChangedCallback.asValidResponseFlow(): Flow<T> = callbackFlow {
+    with { device, data ->
+        T::class.java.newInstance()
+            .apply { onDataReceived(device, data) }
+            .takeIf { it.isValid }
+            ?.let { trySend(it) }
     }
     awaitClose {
         // There's no way to unregister the callback from here.

--- a/ble/src/main/java/no/nordicsemi/android/ble/BleManagerHandler.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/BleManagerHandler.java
@@ -632,8 +632,7 @@ abstract class BleManagerHandler extends RequestHandler {
 			log(Log.INFO, () -> "Disconnected");
 			close();
 			postCallback(c -> c.onDeviceDisconnected(device));
-			postConnectionStateChange(o -> o.onDeviceDisconnected(device, reason)
-			);
+			postConnectionStateChange(o -> o.onDeviceDisconnected(device, reason));
 		}
 		// request may be of type DISCONNECT or CONNECT (timeout).
 		// For the latter, it has already been notified with REASON_TIMEOUT.

--- a/ble/src/main/java/no/nordicsemi/android/ble/Request.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/Request.java
@@ -692,7 +692,7 @@ public abstract class Request {
 	 * After the operation is complete a proper callback will be invoked.
 	 * <p>
 	 * If the read should be triggered by another operation (for example writing an
-	 * op code), set it with {@link WaitForValueChangedRequest#trigger(Operation)}.
+	 * op code), set it with {@link WaitForReadRequest#trigger(Operation)}.
 	 *
 	 * @param characteristic characteristic that should be read by the remote device.
 	 * @return The new request.
@@ -709,7 +709,7 @@ public abstract class Request {
 	 * After the operation is complete a proper callback will be invoked.
 	 * <p>
 	 * If the read should be triggered by another operation (for example writing an
-	 * op code), set it with {@link WaitForValueChangedRequest#trigger(Operation)}.
+	 * op code), set it with {@link WaitForReadRequest#trigger(Operation)}.
 	 *
 	 * @param characteristic characteristic that should be read by the remote device.
 	 * @param value          value to be sent. The array is copied into another buffer so it's
@@ -730,7 +730,7 @@ public abstract class Request {
 	 * After the operation is complete a proper callback will be invoked.
 	 * <p>
 	 * If the read should be triggered by another operation (for example writing an
-	 * op code), set it with {@link WaitForValueChangedRequest#trigger(Operation)}.
+	 * op code), set it with {@link WaitForReadRequest#trigger(Operation)}.
 	 *
 	 * @param characteristic characteristic that should be read by the remote device.
 	 * @param value          value to be sent. The array is copied into another buffer so it's
@@ -753,7 +753,7 @@ public abstract class Request {
 	 * After the operation is complete a proper callback will be invoked.
 	 * <p>
 	 * If the read should be triggered by another operation (for example writing an
-	 * op code), set it with {@link WaitForValueChangedRequest#trigger(Operation)}.
+	 * op code), set it with {@link WaitForReadRequest#trigger(Operation)}.
 	 *
 	 * @param descriptor descriptor that should be read by the remote device.
 	 * @return The new request.
@@ -770,7 +770,7 @@ public abstract class Request {
 	 * After the operation is complete a proper callback will be invoked.
 	 * <p>
 	 * If the read should be triggered by another operation (for example writing an
-	 * op code), set it with {@link WaitForValueChangedRequest#trigger(Operation)}.
+	 * op code), set it with {@link WaitForReadRequest#trigger(Operation)}.
 	 *
 	 * @param descriptor descriptor that should be read by the remote device.
 	 * @param value      value to be sent. The array is copied into another buffer so it's
@@ -791,7 +791,7 @@ public abstract class Request {
 	 * After the operation is complete a proper callback will be invoked.
 	 * <p>
 	 * If the read should be triggered by another operation (for example writing an
-	 * op code), set it with {@link WaitForValueChangedRequest#trigger(Operation)}.
+	 * op code), set it with {@link WaitForReadRequest#trigger(Operation)}.
 	 *
 	 * @param descriptor descriptor that should be read by the remote device.
 	 * @param value      value to be sent. The array is copied into another buffer so it's

--- a/ble/src/main/java/no/nordicsemi/android/ble/response/ConnectionPriorityResponse.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/response/ConnectionPriorityResponse.java
@@ -49,6 +49,10 @@ public class ConnectionPriorityResponse implements ConnectionPriorityCallback, P
 	@IntRange(from = 10, to = 3200)
 	private int supervisionTimeout;
 
+	public ConnectionPriorityResponse() {
+		// empty
+	}
+
 	@Override
 	public void onConnectionUpdated(@NonNull final BluetoothDevice device,
 									@IntRange(from = 6, to = 3200) final int interval,

--- a/ble/src/main/java/no/nordicsemi/android/ble/response/MtuResult.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/response/MtuResult.java
@@ -38,6 +38,10 @@ public class MtuResult implements MtuCallback, Parcelable {
 	@IntRange(from = 23, to = 517)
 	private int mtu;
 
+	public MtuResult() {
+		// empty
+	}
+
 	@Override
 	public void onMtuChanged(@NonNull final BluetoothDevice device,
 							 @IntRange(from = 23, to = 517) final int mtu) {

--- a/ble/src/main/java/no/nordicsemi/android/ble/response/PhyResult.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/response/PhyResult.java
@@ -41,6 +41,10 @@ public class PhyResult implements PhyCallback, Parcelable {
 	@PhyValue
 	private int rxPhy;
 
+	public PhyResult() {
+		// empty
+	}
+
 	@Override
 	public void onPhyChanged(@NonNull final BluetoothDevice device,
 							 @PhyValue final int txPhy, @PhyValue final int rxPhy) {

--- a/ble/src/main/java/no/nordicsemi/android/ble/response/RssiResult.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/response/RssiResult.java
@@ -38,6 +38,10 @@ public class RssiResult implements RssiCallback, Parcelable {
 	@IntRange(from = -128, to = 20)
 	private int rssi;
 
+	public RssiResult() {
+		// empty
+	}
+
 	@Override
 	public void onRssiRead(@NonNull final BluetoothDevice device,
 						   @IntRange(from = -128, to = 20) final int rssi) {

--- a/ble/src/main/java/no/nordicsemi/android/ble/response/WriteResponse.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/response/WriteResponse.java
@@ -41,6 +41,10 @@ public class WriteResponse implements DataSentCallback, Parcelable {
 	private BluetoothDevice device;
 	private Data data;
 
+	public WriteResponse() {
+		// empty
+	}
+
 	@Override
 	public void onDataSent(@NonNull final BluetoothDevice device, @NonNull final Data data) {
 		this.device = device;


### PR DESCRIPTION
This PR added few more Kotlin extensions.
Before it was possible to use `.suspend()` and `.asFlow()`methods, but those were returning `Data`.
With the new extensions it is possible to use automagical parsing, e.g.:

```Kotlin
val hrmMeasurements: Flow<HeartRateMeasurementResponse> = 
    setNotificationCallback(hrmCharacteristic)
        .asValidResponseFlow()
```

or 
```kotlin
scope.launch(exceptionHandler) {
    val alertLevel: AlertLevelResponse = readCharacteristic(alertLevelCharacteristic)
        .suspendForValidResponse()
    // [...]
}
```