### PR TITLE
Deprecating FORMAT_xxx in favor of FORMAT_xxx_LE

### DIFF
--- a/ble-common/src/main/java/no/nordicsemi/android/ble/common/callback/DateTimeDataCallback.java
+++ b/ble-common/src/main/java/no/nordicsemi/android/ble/common/callback/DateTimeDataCallback.java
@@ -81,7 +81,7 @@ public abstract class DateTimeDataCallback extends ProfileReadResponse implement
 			return null;
 
 		final Calendar calendar = Calendar.getInstance();
-		final int year = data.getIntValue(Data.FORMAT_UINT16, offset);
+		final int year = data.getIntValue(Data.FORMAT_UINT16_LE, offset);
 		final int month = data.getIntValue(Data.FORMAT_UINT8, offset + 2);
 		final int day = data.getIntValue(Data.FORMAT_UINT8, offset + 3);
 		if (year > 0)

--- a/ble-common/src/main/java/no/nordicsemi/android/ble/common/callback/RecordAccessControlPointDataCallback.java
+++ b/ble-common/src/main/java/no/nordicsemi/android/ble/common/callback/RecordAccessControlPointDataCallback.java
@@ -83,10 +83,10 @@ public abstract class RecordAccessControlPointDataCallback extends ProfileReadRe
 						numberOfRecords = data.getIntValue(Data.FORMAT_UINT8, 2);
 						break;
 					case 2:
-						numberOfRecords = data.getIntValue(Data.FORMAT_UINT16, 2);
+						numberOfRecords = data.getIntValue(Data.FORMAT_UINT16_LE, 2);
 						break;
 					case 4:
-						numberOfRecords = data.getIntValue(Data.FORMAT_UINT32, 2);
+						numberOfRecords = data.getIntValue(Data.FORMAT_UINT32_LE, 2);
 						break;
 					default:
 						// Other field sizes are not supported

--- a/ble-common/src/main/java/no/nordicsemi/android/ble/common/callback/bps/BloodPressureMeasurementDataCallback.java
+++ b/ble-common/src/main/java/no/nordicsemi/android/ble/common/callback/bps/BloodPressureMeasurementDataCallback.java
@@ -106,7 +106,7 @@ public abstract class BloodPressureMeasurementDataCallback extends ProfileReadRe
 		// Read measurement status if present
 		BPMStatus status = null;
 		if (measurementStatusPresent) {
-			final int measurementStatus = data.getIntValue(Data.FORMAT_UINT16, offset);
+			final int measurementStatus = data.getIntValue(Data.FORMAT_UINT16_LE, offset);
 			// offset += 2;
 			status = new BPMStatus(measurementStatus);
 		}

--- a/ble-common/src/main/java/no/nordicsemi/android/ble/common/callback/bps/IntermediateCuffPressureDataCallback.java
+++ b/ble-common/src/main/java/no/nordicsemi/android/ble/common/callback/bps/IntermediateCuffPressureDataCallback.java
@@ -106,7 +106,7 @@ public abstract class IntermediateCuffPressureDataCallback extends ProfileReadRe
 		// Read measurement status if present
 		BPMStatus status = null;
 		if (measurementStatusPresent) {
-			final int measurementStatus = data.getIntValue(Data.FORMAT_UINT16, offset);
+			final int measurementStatus = data.getIntValue(Data.FORMAT_UINT16_LE, offset);
 			// offset += 2;
 			status = new BPMStatus(measurementStatus);
 		}

--- a/ble-common/src/main/java/no/nordicsemi/android/ble/common/callback/cgm/CGMFeatureDataCallback.java
+++ b/ble-common/src/main/java/no/nordicsemi/android/ble/common/callback/cgm/CGMFeatureDataCallback.java
@@ -61,9 +61,9 @@ public abstract class CGMFeatureDataCallback extends ProfileReadResponse impleme
 			return;
 		}
 
-		final int featuresValue = data.getIntValue(Data.FORMAT_UINT24, 0);
+		final int featuresValue = data.getIntValue(Data.FORMAT_UINT24_LE, 0);
 		final int typeAndSampleLocation = data.getIntValue(Data.FORMAT_UINT8, 3);
-		final int expectedCrc = data.getIntValue(Data.FORMAT_UINT16, 4);
+		final int expectedCrc = data.getIntValue(Data.FORMAT_UINT16_LE, 4);
 
 		final CGMFeatures features = new CGMFeatures(featuresValue);
 		if (features.e2eCrcSupported) {

--- a/ble-common/src/main/java/no/nordicsemi/android/ble/common/callback/cgm/CGMSessionRunTimeDataCallback.java
+++ b/ble-common/src/main/java/no/nordicsemi/android/ble/common/callback/cgm/CGMSessionRunTimeDataCallback.java
@@ -60,12 +60,12 @@ public abstract class CGMSessionRunTimeDataCallback extends ProfileReadResponse 
 			return;
 		}
 
-		final int sessionRunTime = data.getIntValue(Data.FORMAT_UINT16, 0);
+		final int sessionRunTime = data.getIntValue(Data.FORMAT_UINT16_LE, 0);
 
 		final boolean crcPresent = data.size() == 4;
 		if (crcPresent) {
 			final int actualCrc = CRC16.MCRF4XX(data.getValue(), 0, 2);
-			final int expectedCrc = data.getIntValue(Data.FORMAT_UINT16, 2);
+			final int expectedCrc = data.getIntValue(Data.FORMAT_UINT16_LE, 2);
 			if (actualCrc != expectedCrc) {
 				onContinuousGlucoseMonitorSessionRunTimeReceivedWithCrcError(device, data);
 				return;

--- a/ble-common/src/main/java/no/nordicsemi/android/ble/common/callback/cgm/CGMSessionStartTimeDataCallback.java
+++ b/ble-common/src/main/java/no/nordicsemi/android/ble/common/callback/cgm/CGMSessionStartTimeDataCallback.java
@@ -71,7 +71,7 @@ public abstract class CGMSessionStartTimeDataCallback extends ProfileReadRespons
 		final boolean crcPresent = data.size() == 11;
 		if (crcPresent) {
 			final int actualCrc = CRC16.MCRF4XX(data.getValue(), 0, 9);
-			final int expectedCrc = data.getIntValue(Data.FORMAT_UINT16, 9);
+			final int expectedCrc = data.getIntValue(Data.FORMAT_UINT16_LE, 9);
 			if (actualCrc != expectedCrc) {
 				onContinuousGlucoseMonitorSessionStartTimeReceivedWithCrcError(device, data);
 				return;

--- a/ble-common/src/main/java/no/nordicsemi/android/ble/common/callback/cgm/CGMSpecificOpsControlPointDataCallback.java
+++ b/ble-common/src/main/java/no/nordicsemi/android/ble/common/callback/cgm/CGMSpecificOpsControlPointDataCallback.java
@@ -112,7 +112,7 @@ public abstract class CGMSpecificOpsControlPointDataCallback extends ProfileRead
 		// Verify CRC if present
 		final boolean crcPresent = data.size() == 1 + expectedOperandSize + 2; // opCode + expected operand + CRC
 		if (crcPresent) {
-			final int expectedCrc = data.getIntValue(Data.FORMAT_UINT16, 1 + expectedOperandSize);
+			final int expectedCrc = data.getIntValue(Data.FORMAT_UINT16_LE, 1 + expectedOperandSize);
 			final int actualCrc   = CRC16.MCRF4XX(data.getValue(), 0, 1 + expectedOperandSize);
 			if (expectedCrc != actualCrc) {
 				onCGMSpecificOpsResponseReceivedWithCrcError(device, data);
@@ -127,13 +127,13 @@ public abstract class CGMSpecificOpsControlPointDataCallback extends ProfileRead
 				return;
 			case OP_CODE_CALIBRATION_VALUE_RESPONSE:
 				final float glucoseConcentrationOfCalibration = data.getFloatValue(Data.FORMAT_SFLOAT, 1);
-				final int calibrationTime = data.getIntValue(Data.FORMAT_UINT16, 3);
+				final int calibrationTime = data.getIntValue(Data.FORMAT_UINT16_LE, 3);
 				final int calibrationTypeAndSampleLocation = data.getIntValue(Data.FORMAT_UINT8, 5);
 				@SuppressLint("WrongConstant")
 				final int calibrationType = calibrationTypeAndSampleLocation & 0x0F;
 				final int calibrationSampleLocation = calibrationTypeAndSampleLocation >> 4;
-				final int nextCalibrationTime = data.getIntValue(Data.FORMAT_UINT16, 6);
-				final int calibrationDataRecordNumber = data.getIntValue(Data.FORMAT_UINT16, 8);
+				final int nextCalibrationTime = data.getIntValue(Data.FORMAT_UINT16_LE, 6);
+				final int calibrationDataRecordNumber = data.getIntValue(Data.FORMAT_UINT16_LE, 8);
 				final int calibrationStatus = data.getIntValue(Data.FORMAT_UINT8, 10);
 				onContinuousGlucoseCalibrationValueReceived(device, glucoseConcentrationOfCalibration,
 						calibrationTime, nextCalibrationTime, calibrationType, calibrationSampleLocation,

--- a/ble-common/src/main/java/no/nordicsemi/android/ble/common/callback/cgm/CGMStatusDataCallback.java
+++ b/ble-common/src/main/java/no/nordicsemi/android/ble/common/callback/cgm/CGMStatusDataCallback.java
@@ -60,7 +60,7 @@ public abstract class CGMStatusDataCallback extends ProfileReadResponse implemen
 			return;
 		}
 
-		final int timeOffset = data.getIntValue(Data.FORMAT_UINT16, 0);
+		final int timeOffset = data.getIntValue(Data.FORMAT_UINT16_LE, 0);
 		final int warningStatus = data.getIntValue(Data.FORMAT_UINT8, 2);
 		final int calibrationTempStatus = data.getIntValue(Data.FORMAT_UINT8, 3);
 		final int sensorStatus = data.getIntValue(Data.FORMAT_UINT8, 4);
@@ -68,7 +68,7 @@ public abstract class CGMStatusDataCallback extends ProfileReadResponse implemen
 		final boolean crcPresent = data.size() == 7;
 		if (crcPresent) {
 			final int actualCrc = CRC16.MCRF4XX(data.getValue(), 0, 5);
-			final int expectedCrc = data.getIntValue(Data.FORMAT_UINT16, 5);
+			final int expectedCrc = data.getIntValue(Data.FORMAT_UINT16_LE, 5);
 			if (actualCrc != expectedCrc) {
 				onContinuousGlucoseMonitorStatusReceivedWithCrcError(device, data);
 				return;

--- a/ble-common/src/main/java/no/nordicsemi/android/ble/common/callback/cgm/ContinuousGlucoseMeasurementDataCallback.java
+++ b/ble-common/src/main/java/no/nordicsemi/android/ble/common/callback/cgm/ContinuousGlucoseMeasurementDataCallback.java
@@ -91,7 +91,7 @@ public abstract class ContinuousGlucoseMeasurementDataCallback extends ProfileRe
 
 			final boolean crcPresent = size == dataSize + 2;
 			if (crcPresent) {
-				final int expectedCrc = data.getIntValue(Data.FORMAT_UINT16, offset + dataSize);
+				final int expectedCrc = data.getIntValue(Data.FORMAT_UINT16_LE, offset + dataSize);
 				final int actualCrc = CRC16.MCRF4XX(data.getValue(), offset, dataSize);
 				if (expectedCrc != actualCrc) {
 					onContinuousGlucoseMeasurementReceivedWithCrcError(device, data);
@@ -105,7 +105,7 @@ public abstract class ContinuousGlucoseMeasurementDataCallback extends ProfileRe
 			offset += 2;
 
 			// Time offset (in minutes since Session Start)
-			final int timeOffset = data.getIntValue(Data.FORMAT_UINT16, offset);
+			final int timeOffset = data.getIntValue(Data.FORMAT_UINT16_LE, offset);
 			offset += 2;
 
 			// Sensor Status Annunciation

--- a/ble-common/src/main/java/no/nordicsemi/android/ble/common/callback/csc/CyclingSpeedAndCadenceFeatureDataCallback.java
+++ b/ble-common/src/main/java/no/nordicsemi/android/ble/common/callback/csc/CyclingSpeedAndCadenceFeatureDataCallback.java
@@ -57,7 +57,7 @@ public abstract class CyclingSpeedAndCadenceFeatureDataCallback extends ProfileR
 			return;
 		}
 
-		final int value = data.getIntValue(Data.FORMAT_UINT16, 0);
+		final int value = data.getIntValue(Data.FORMAT_UINT16_LE, 0);
 		final CSCFeatures features = new CSCFeatures(value);
 		onCyclingSpeedAndCadenceFeaturesReceived(device, features);
 	}

--- a/ble-common/src/main/java/no/nordicsemi/android/ble/common/callback/csc/CyclingSpeedAndCadenceMeasurementDataCallback.java
+++ b/ble-common/src/main/java/no/nordicsemi/android/ble/common/callback/csc/CyclingSpeedAndCadenceMeasurementDataCallback.java
@@ -79,10 +79,10 @@ public abstract class CyclingSpeedAndCadenceMeasurementDataCallback extends Prof
 		}
 
 		if (wheelRevPresent) {
-			final long wheelRevolutions = data.getIntValue(Data.FORMAT_UINT32, offset) & 0xFFFFFFFFL;
+			final long wheelRevolutions = data.getIntValue(Data.FORMAT_UINT32_LE, offset) & 0xFFFFFFFFL;
 			offset += 4;
 
-			final int lastWheelEventTime = data.getIntValue(Data.FORMAT_UINT16, offset); // 1/1024 s
+			final int lastWheelEventTime = data.getIntValue(Data.FORMAT_UINT16_LE, offset); // 1/1024 s
 			offset += 2;
 
 			if (mInitialWheelRevolutions < 0)
@@ -93,10 +93,10 @@ public abstract class CyclingSpeedAndCadenceMeasurementDataCallback extends Prof
 		}
 
 		if (crankRevPreset) {
-			final int crankRevolutions = data.getIntValue(Data.FORMAT_UINT16, offset);
+			final int crankRevolutions = data.getIntValue(Data.FORMAT_UINT16_LE, offset);
 			offset += 2;
 
-			final int lastCrankEventTime = data.getIntValue(Data.FORMAT_UINT16, offset);
+			final int lastCrankEventTime = data.getIntValue(Data.FORMAT_UINT16_LE, offset);
 			// offset += 2;
 
 			// Notify listener about the new measurement

--- a/ble-common/src/main/java/no/nordicsemi/android/ble/common/callback/glucose/GlucoseFeatureDataCallback.java
+++ b/ble-common/src/main/java/no/nordicsemi/android/ble/common/callback/glucose/GlucoseFeatureDataCallback.java
@@ -57,7 +57,7 @@ public abstract class GlucoseFeatureDataCallback extends ProfileReadResponse imp
 			return;
 		}
 
-		final int value = data.getIntValue(Data.FORMAT_UINT16, 0);
+		final int value = data.getIntValue(Data.FORMAT_UINT16_LE, 0);
 		final GlucoseFeatures features = new GlucoseFeatures(value);
 		onGlucoseFeaturesReceived(device, features);
 	}

--- a/ble-common/src/main/java/no/nordicsemi/android/ble/common/callback/glucose/GlucoseMeasurementContextDataCallback.java
+++ b/ble-common/src/main/java/no/nordicsemi/android/ble/common/callback/glucose/GlucoseMeasurementContextDataCallback.java
@@ -76,7 +76,7 @@ public abstract class GlucoseMeasurementContextDataCallback extends ProfileReadR
 			return;
 		}
 
-		final int sequenceNumber = data.getIntValue(Data.FORMAT_UINT16, offset);
+		final int sequenceNumber = data.getIntValue(Data.FORMAT_UINT16_LE, offset);
 		offset += 2;
 
 		// Optional fields
@@ -113,7 +113,7 @@ public abstract class GlucoseMeasurementContextDataCallback extends ProfileReadR
 		Integer exerciseDuration = null;
 		Integer exerciseIntensity = null;
 		if (exercisePresent) {
-			exerciseDuration = data.getIntValue(Data.FORMAT_UINT16, offset); // in seconds
+			exerciseDuration = data.getIntValue(Data.FORMAT_UINT16_LE, offset); // in seconds
 			exerciseIntensity = data.getIntValue(Data.FORMAT_UINT8, offset + 2); // in percentage
 			offset += 3;
 		}

--- a/ble-common/src/main/java/no/nordicsemi/android/ble/common/callback/glucose/GlucoseMeasurementDataCallback.java
+++ b/ble-common/src/main/java/no/nordicsemi/android/ble/common/callback/glucose/GlucoseMeasurementDataCallback.java
@@ -76,7 +76,7 @@ public abstract class GlucoseMeasurementDataCallback extends ProfileReadResponse
 		}
 
 		// Required fields
-		final int sequenceNumber = data.getIntValue(Data.FORMAT_UINT16, offset);
+		final int sequenceNumber = data.getIntValue(Data.FORMAT_UINT16_LE, offset);
 		offset += 2;
 		final Calendar baseTime = DateTimeDataCallback.readDateTime(data, 3);
 		offset += 7;
@@ -88,7 +88,7 @@ public abstract class GlucoseMeasurementDataCallback extends ProfileReadResponse
 
 		// Optional fields
 		if (timeOffsetPresent) {
-			final int timeOffset = data.getIntValue(Data.FORMAT_SINT16, offset);
+			final int timeOffset = data.getIntValue(Data.FORMAT_SINT16_LE, offset);
 			offset += 2;
 
 			baseTime.add(Calendar.MINUTE, timeOffset);
@@ -110,7 +110,7 @@ public abstract class GlucoseMeasurementDataCallback extends ProfileReadResponse
 
 		GlucoseStatus status = null;
 		if (sensorStatusAnnunciationPresent) {
-			final int value = data.getIntValue(Data.FORMAT_UINT16, offset);
+			final int value = data.getIntValue(Data.FORMAT_UINT16_LE, offset);
 			// offset += 2;
 
 			status = new GlucoseStatus(value);

--- a/ble-common/src/main/java/no/nordicsemi/android/ble/common/callback/hr/HeartRateMeasurementDataCallback.java
+++ b/ble-common/src/main/java/no/nordicsemi/android/ble/common/callback/hr/HeartRateMeasurementDataCallback.java
@@ -64,7 +64,7 @@ public abstract class HeartRateMeasurementDataCallback extends ProfileReadRespon
 		// Read flags
 		int offset = 0;
 		final int flags = data.getIntValue(Data.FORMAT_UINT8, offset);
-		final int hearRateType = (flags & 0x01) == 0 ? Data.FORMAT_UINT8 : Data.FORMAT_UINT16;
+		final int hearRateType = (flags & 0x01) == 0 ? Data.FORMAT_UINT8 : Data.FORMAT_UINT16_LE;
 		final int sensorContactStatus = (flags & 0x06) >> 1;
 		final boolean sensorContactSupported = sensorContactStatus == 2 || sensorContactStatus == 3;
 		final boolean sensorContactDetected = sensorContactStatus == 3;
@@ -88,7 +88,7 @@ public abstract class HeartRateMeasurementDataCallback extends ProfileReadRespon
 
 		Integer energyExpanded = null;
 		if (energyExpandedPresent) {
-			energyExpanded = data.getIntValue(Data.FORMAT_UINT16, offset);
+			energyExpanded = data.getIntValue(Data.FORMAT_UINT16_LE, offset);
 			offset += 2;
 		}
 
@@ -97,7 +97,7 @@ public abstract class HeartRateMeasurementDataCallback extends ProfileReadRespon
 			final int count = (data.size() - offset) / 2;
 			final List<Integer> intervals = new ArrayList<>(count);
 			for (int i = 0; i < count; ++i) {
-				intervals.add(data.getIntValue(Data.FORMAT_UINT16, offset));
+				intervals.add(data.getIntValue(Data.FORMAT_UINT16_LE, offset));
 				offset += 2;
 			}
 			rrIntervals = Collections.unmodifiableList(intervals);

--- a/ble-common/src/main/java/no/nordicsemi/android/ble/common/callback/ht/MeasurementIntervalDataCallback.java
+++ b/ble-common/src/main/java/no/nordicsemi/android/ble/common/callback/ht/MeasurementIntervalDataCallback.java
@@ -57,7 +57,7 @@ public abstract class MeasurementIntervalDataCallback extends ProfileReadRespons
 			return;
 		}
 
-		final int interval = data.getIntValue(Data.FORMAT_UINT16, 0);
+		final int interval = data.getIntValue(Data.FORMAT_UINT16_LE, 0);
 		onMeasurementIntervalReceived(device, interval);
 	}
 }

--- a/ble-common/src/main/java/no/nordicsemi/android/ble/common/callback/rsc/RunningSpeedAndCadenceFeatureDataCallback.java
+++ b/ble-common/src/main/java/no/nordicsemi/android/ble/common/callback/rsc/RunningSpeedAndCadenceFeatureDataCallback.java
@@ -57,7 +57,7 @@ public abstract class RunningSpeedAndCadenceFeatureDataCallback extends ProfileR
 			return;
 		}
 
-		final int value = data.getIntValue(Data.FORMAT_UINT16, 0);
+		final int value = data.getIntValue(Data.FORMAT_UINT16_LE, 0);
 		final RSCFeatures features = new RSCFeatures(value);
 		onRunningSpeedAndCadenceFeaturesReceived(device, features);
 	}

--- a/ble-common/src/main/java/no/nordicsemi/android/ble/common/callback/rsc/RunningSpeedAndCadenceMeasurementDataCallback.java
+++ b/ble-common/src/main/java/no/nordicsemi/android/ble/common/callback/rsc/RunningSpeedAndCadenceMeasurementDataCallback.java
@@ -65,7 +65,7 @@ public abstract class RunningSpeedAndCadenceMeasurementDataCallback extends Prof
 		final boolean statusRunning = (flags & 0x04) != 0;
 		offset += 1;
 
-		final float speed = data.getIntValue(Data.FORMAT_UINT16, offset) / 256.f; // [m/s]
+		final float speed = data.getIntValue(Data.FORMAT_UINT16_LE, offset) / 256.f; // [m/s]
 		offset += 2;
 		final int cadence = data.getIntValue(Data.FORMAT_UINT8, offset);
 		offset += 1;
@@ -79,13 +79,13 @@ public abstract class RunningSpeedAndCadenceMeasurementDataCallback extends Prof
 
 		Integer strideLength = null;
 		if (instantaneousStrideLengthPresent) {
-			strideLength = data.getIntValue(Data.FORMAT_UINT16, offset);
+			strideLength = data.getIntValue(Data.FORMAT_UINT16_LE, offset);
 			offset += 2;
 		}
 
 		Long totalDistance = null;
 		if (totalDistancePresent) {
-			totalDistance = data.getLongValue(Data.FORMAT_UINT32, offset);
+			totalDistance = data.getLongValue(Data.FORMAT_UINT32_LE, offset);
 			// offset += 4;
 		}
 

--- a/ble-common/src/main/java/no/nordicsemi/android/ble/common/data/RecordAccessControlPointData.java
+++ b/ble-common/src/main/java/no/nordicsemi/android/ble/common/data/RecordAccessControlPointData.java
@@ -97,18 +97,18 @@ public final class RecordAccessControlPointData {
 
 	public static Data reportStoredRecordsLessThenOrEqualTo(@IntRange(from = 0) final int sequenceNumber) {
 		return create(OP_CODE_REPORT_STORED_RECORDS, OPERATOR_LESS_THEN_OR_EQUAL,
-				FilterType.SEQUENCE_NUMBER, Data.FORMAT_UINT16, sequenceNumber);
+				FilterType.SEQUENCE_NUMBER, Data.FORMAT_UINT16_LE, sequenceNumber);
 	}
 
 	public static Data reportStoredRecordsGreaterThenOrEqualTo(@IntRange(from = 0) final int sequenceNumber) {
 		return create(OP_CODE_REPORT_STORED_RECORDS, OPERATOR_GREATER_THEN_OR_EQUAL,
-				FilterType.SEQUENCE_NUMBER, Data.FORMAT_UINT16, sequenceNumber);
+				FilterType.SEQUENCE_NUMBER, Data.FORMAT_UINT16_LE, sequenceNumber);
 	}
 
 	public static Data reportStoredRecordsFromRange(@IntRange(from = 0) final int startSequenceNumber,
 													@IntRange(from = 0) final int endSequenceNumber) {
 		return create(OP_CODE_REPORT_STORED_RECORDS, OPERATOR_WITHING_RANGE,
-				FilterType.SEQUENCE_NUMBER, Data.FORMAT_UINT16,
+				FilterType.SEQUENCE_NUMBER, Data.FORMAT_UINT16_LE,
 				startSequenceNumber, endSequenceNumber);
 	}
 
@@ -147,18 +147,18 @@ public final class RecordAccessControlPointData {
 
 	public static Data deleteStoredRecordsLessThenOrEqualTo(@IntRange(from = 0) final int sequenceNumber) {
 		return create(OP_CODE_DELETE_STORED_RECORDS, OPERATOR_LESS_THEN_OR_EQUAL,
-				FilterType.SEQUENCE_NUMBER, Data.FORMAT_UINT16, sequenceNumber);
+				FilterType.SEQUENCE_NUMBER, Data.FORMAT_UINT16_LE, sequenceNumber);
 	}
 
 	public static Data deleteStoredRecordsGreaterThenOrEqualTo(@IntRange(from = 0) final int sequenceNumber) {
 		return create(OP_CODE_DELETE_STORED_RECORDS, OPERATOR_GREATER_THEN_OR_EQUAL,
-				FilterType.SEQUENCE_NUMBER, Data.FORMAT_UINT16, sequenceNumber);
+				FilterType.SEQUENCE_NUMBER, Data.FORMAT_UINT16_LE, sequenceNumber);
 	}
 
 	public static Data deleteStoredRecordsFromRange(@IntRange(from = 0) final int startSequenceNumber,
 													@IntRange(from = 0) final int endSequenceNumber) {
 		return create(OP_CODE_DELETE_STORED_RECORDS, OPERATOR_WITHING_RANGE,
-				FilterType.SEQUENCE_NUMBER, Data.FORMAT_UINT16,
+				FilterType.SEQUENCE_NUMBER, Data.FORMAT_UINT16_LE,
 				startSequenceNumber, endSequenceNumber);
 	}
 
@@ -189,18 +189,18 @@ public final class RecordAccessControlPointData {
 
 	public static Data reportNumberOfStoredRecordsLessThenOrEqualTo(@IntRange(from = 0) final int sequenceNumber) {
 		return create(OP_CODE_REPORT_NUMBER_OF_RECORDS, OPERATOR_LESS_THEN_OR_EQUAL,
-				FilterType.SEQUENCE_NUMBER, Data.FORMAT_UINT16, sequenceNumber);
+				FilterType.SEQUENCE_NUMBER, Data.FORMAT_UINT16_LE, sequenceNumber);
 	}
 
 	public static Data reportNumberOfStoredRecordsGreaterThenOrEqualTo(@IntRange(from = 0) final int sequenceNumber) {
 		return create(OP_CODE_REPORT_NUMBER_OF_RECORDS, OPERATOR_GREATER_THEN_OR_EQUAL,
-				FilterType.SEQUENCE_NUMBER, Data.FORMAT_UINT16, sequenceNumber);
+				FilterType.SEQUENCE_NUMBER, Data.FORMAT_UINT16_LE, sequenceNumber);
 	}
 
 	public static Data reportNumberOfStoredRecordsFromRange(@IntRange(from = 0) final int startSequenceNumber,
 															@IntRange(from = 0) final int endSequenceNumber) {
 		return create(OP_CODE_REPORT_NUMBER_OF_RECORDS, OPERATOR_WITHING_RANGE,
-				FilterType.SEQUENCE_NUMBER, Data.FORMAT_UINT16,
+				FilterType.SEQUENCE_NUMBER, Data.FORMAT_UINT16_LE,
 				startSequenceNumber, endSequenceNumber);
 	}
 

--- a/ble-common/src/main/java/no/nordicsemi/android/ble/common/data/cgm/CGMSpecificOpsControlPointData.java
+++ b/ble-common/src/main/java/no/nordicsemi/android/ble/common/data/cgm/CGMSpecificOpsControlPointData.java
@@ -96,21 +96,21 @@ public final class CGMSpecificOpsControlPointData implements CGMTypes {
 		final MutableData data = new MutableData(new byte[11 + (secure ? 2 : 0)]);
 		data.setByte(OP_CODE_SET_CALIBRATION_VALUE, 0);
 		data.setValue(glucoseConcentrationOfCalibration, Data.FORMAT_SFLOAT, 1);
-		data.setValue(calibrationTime, Data.FORMAT_UINT16, 3);
+		data.setValue(calibrationTime, Data.FORMAT_UINT16_LE, 3);
 		final int typeAndSampleLocation = ((sampleLocation & 0xF) << 8) | (sampleType & 0xF);
 		data.setValue(typeAndSampleLocation, Data.FORMAT_UINT8, 5);
-		data.setValue(nextCalibrationTime, Data.FORMAT_UINT16, 6);
-		data.setValue(0, Data.FORMAT_UINT16, 8); // ignored: calibration data record number
+		data.setValue(nextCalibrationTime, Data.FORMAT_UINT16_LE, 6);
+		data.setValue(0, Data.FORMAT_UINT16_LE, 8); // ignored: calibration data record number
 		data.setValue(0, Data.FORMAT_UINT8, 10); // ignored: calibration status
 		return appendCrc(data, secure);
 	}
 
 	public static Data getCalibrationValue(@IntRange(from = 0) final int calibrationDataRecordNumber, final boolean secure) {
-		return create(OP_CODE_GET_CALIBRATION_VALUE, calibrationDataRecordNumber, Data.FORMAT_UINT16, secure);
+		return create(OP_CODE_GET_CALIBRATION_VALUE, calibrationDataRecordNumber, Data.FORMAT_UINT16_LE, secure);
 	}
 
 	public static Data getLastCalibrationValue(final boolean secure) {
-		return create(OP_CODE_GET_CALIBRATION_VALUE, 0xFFFF, Data.FORMAT_UINT16, secure);
+		return create(OP_CODE_GET_CALIBRATION_VALUE, 0xFFFF, Data.FORMAT_UINT16_LE, secure);
 	}
 
 	public static Data setPatientHighAlertLevel(@FloatRange(from = 0) final float level,
@@ -192,7 +192,7 @@ public final class CGMSpecificOpsControlPointData implements CGMTypes {
 		if (secure) {
 			final int length = data.size() - 2;
 			final int crc = CRC16.MCRF4XX(data.getValue(), 0, length);
-			data.setValue(crc, Data.FORMAT_UINT16, length);
+			data.setValue(crc, Data.FORMAT_UINT16_LE, length);
 		}
 		return data;
 	}

--- a/ble-common/src/main/java/no/nordicsemi/android/ble/common/data/sc/SpeedAndCadenceControlPointData.java
+++ b/ble-common/src/main/java/no/nordicsemi/android/ble/common/data/sc/SpeedAndCadenceControlPointData.java
@@ -44,7 +44,7 @@ public final class SpeedAndCadenceControlPointData implements SensorLocationType
 	public static Data setCumulativeValue(final long value) {
 		final MutableData data = new MutableData(new byte[5]);
 		data.setByte(SC_OP_CODE_SET_CUMULATIVE_VALUE, 0);
-		data.setValue(value, Data.FORMAT_UINT32, 1);
+		data.setValue(value, Data.FORMAT_UINT32_LE, 1);
 		return data;
 	}
 

--- a/ble-common/src/test/java/no/nordicsemi/android/ble/common/callback/bps/BloodPressureMeasurementDataCallbackTest.java
+++ b/ble-common/src/test/java/no/nordicsemi/android/ble/common/callback/bps/BloodPressureMeasurementDataCallbackTest.java
@@ -88,7 +88,7 @@ public class BloodPressureMeasurementDataCallbackTest {
 		data.setValue(88, 0, Data.FORMAT_SFLOAT, 3);
 		data.setValue(120, 0, Data.FORMAT_SFLOAT, 5);
 		// Date and Time
-		data.setValue(0, Data.FORMAT_UINT16, 7);
+		data.setValue(0, Data.FORMAT_UINT16_LE, 7);
 		data.setValue(4, Data.FORMAT_UINT8, 9);
 		data.setValue(17, Data.FORMAT_UINT8, 10);
 		data.setValue(20, Data.FORMAT_UINT8, 11);
@@ -99,7 +99,7 @@ public class BloodPressureMeasurementDataCallbackTest {
 		// User ID
 		data.setValue(1, Data.FORMAT_UINT8, 16);
 		// Measurement status
-		data.setValue(0b100111, Data.FORMAT_UINT16, 17);
+		data.setValue(0b100111, Data.FORMAT_UINT16_LE, 17);
 
 		assertArrayEquals(
 				new byte[] { 0x1E, (byte) 0x8A, 0x00, 0x58, 0x00, 0x78, 0x00, 0x00, 0x00, 0x04, 0x11, 0x14, 0x29, 0x3B, 0x3C, 0x00, 0x01, 0x27, 0x00 },
@@ -150,7 +150,7 @@ public class BloodPressureMeasurementDataCallbackTest {
 		// Pulse rate
 		data.setValue(60, 0, Data.FORMAT_SFLOAT, 7);
 		// Measurement status
-		data.setValue(0b010010, Data.FORMAT_UINT16, 9);
+		data.setValue(0b010010, Data.FORMAT_UINT16_LE, 9);
 
 		assertArrayEquals(
 				new byte[] { 0x15, (byte) 0xBD, (byte) 0xF0, 0xB, 0x0, (byte) 0x9F, (byte) 0xF0, 0x3C, 0x0, 0x12, 0x0 },

--- a/ble-common/src/test/java/no/nordicsemi/android/ble/common/callback/bps/IntermediateCuffPressureDataCallbackTest.java
+++ b/ble-common/src/test/java/no/nordicsemi/android/ble/common/callback/bps/IntermediateCuffPressureDataCallbackTest.java
@@ -89,7 +89,7 @@ public class IntermediateCuffPressureDataCallbackTest {
 		// Cuff pressure in mmHg
 		data.setValue(4, 0, Data.FORMAT_SFLOAT, 1);
 		// Date and Time
-		data.setValue(0, Data.FORMAT_UINT16, 7);
+		data.setValue(0, Data.FORMAT_UINT16_LE, 7);
 		data.setValue(4, Data.FORMAT_UINT8, 9);
 		data.setValue(17, Data.FORMAT_UINT8, 10);
 		data.setValue(20, Data.FORMAT_UINT8, 11);
@@ -100,7 +100,7 @@ public class IntermediateCuffPressureDataCallbackTest {
 		// User ID
 		data.setValue(1, Data.FORMAT_UINT8, 16);
 		// Measurement status
-		data.setValue(0b100111, Data.FORMAT_UINT16, 17);
+		data.setValue(0b100111, Data.FORMAT_UINT16_LE, 17);
 
 		assertArrayEquals(
 				new byte[] { 0x1E, (byte) 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x04, 0x11, 0x14, 0x29, 0x3B, 0x3C, 0x00, 0x01, 0x27, 0x00 },
@@ -147,7 +147,7 @@ public class IntermediateCuffPressureDataCallbackTest {
 		// Pulse rate
 		data.setValue(60, 0, Data.FORMAT_SFLOAT, 7);
 		// Measurement status
-		data.setValue(0b010010, Data.FORMAT_UINT16, 9);
+		data.setValue(0b010010, Data.FORMAT_UINT16_LE, 9);
 
 		assertArrayEquals(
 				new byte[] { 0x15, 0x6F, (byte) 0xF0, 0x00, 0x00, 0x00, 0x00, 0x3C, 0x0, 0x12, 0x0 },

--- a/ble-common/src/test/java/no/nordicsemi/android/ble/common/callback/cgm/CGMFeatureDataCallbackTest.java
+++ b/ble-common/src/test/java/no/nordicsemi/android/ble/common/callback/cgm/CGMFeatureDataCallbackTest.java
@@ -81,9 +81,9 @@ public class CGMFeatureDataCallbackTest {
 			}
 		};
 		final MutableData data = new MutableData(new byte[6]);
-		assertTrue(data.setValue(0b11001111001101110, Data.FORMAT_UINT24, 0));
+		assertTrue(data.setValue(0b11001111001101110, Data.FORMAT_UINT24_LE, 0));
 		assertTrue(data.setValue(0x16, Data.FORMAT_UINT8, 3));
-		assertTrue(data.setValue(0xC18A, Data.FORMAT_UINT16, 4));
+		assertTrue(data.setValue(0xC18A, Data.FORMAT_UINT16_LE, 4));
 		called = false;
 		callback.onDataReceived(null, data);
 		assertTrue(called);
@@ -130,9 +130,9 @@ public class CGMFeatureDataCallbackTest {
 			}
 		};
 		final MutableData data = new MutableData(new byte[6]);
-		data.setValue(0b11000111001101110, Data.FORMAT_UINT24, 0);
+		data.setValue(0b11000111001101110, Data.FORMAT_UINT24_LE, 0);
 		data.setValue(0x16, Data.FORMAT_UINT8, 3);
-		data.setValue(0xFFFF, Data.FORMAT_UINT16, 4);
+		data.setValue(0xFFFF, Data.FORMAT_UINT16_LE, 4);
 		called = false;
 		callback.onDataReceived(null, data);
 		assertTrue(called);
@@ -158,9 +158,9 @@ public class CGMFeatureDataCallbackTest {
 			}
 		};
 		final MutableData data = new MutableData(new byte[6]);
-		assertTrue(data.setValue(0b11001111001101110, Data.FORMAT_UINT24, 0));
+		assertTrue(data.setValue(0b11001111001101110, Data.FORMAT_UINT24_LE, 0));
 		assertTrue(data.setValue(0x16, Data.FORMAT_UINT8, 3));
-		assertTrue(data.setValue(0xBEAF, Data.FORMAT_UINT16, 4));
+		assertTrue(data.setValue(0xBEAF, Data.FORMAT_UINT16_LE, 4));
 		called = false;
 		callback.onDataReceived(null, data);
 		assertTrue(called);
@@ -186,7 +186,7 @@ public class CGMFeatureDataCallbackTest {
 			}
 		};
 		final MutableData data = new MutableData(new byte[4]);
-		assertTrue(data.setValue(0b11001111001101110, Data.FORMAT_UINT24, 0));
+		assertTrue(data.setValue(0b11001111001101110, Data.FORMAT_UINT24_LE, 0));
 		assertTrue(data.setValue(0x16, Data.FORMAT_UINT8, 3));
 		called = false;
 		callback.onDataReceived(null, data);
@@ -213,9 +213,9 @@ public class CGMFeatureDataCallbackTest {
 			}
 		};
 		final MutableData data = new MutableData(new byte[6]);
-		assertTrue(data.setValue(0b11000111001101110, Data.FORMAT_UINT24, 0));
+		assertTrue(data.setValue(0b11000111001101110, Data.FORMAT_UINT24_LE, 0));
 		assertTrue(data.setValue(0x16, Data.FORMAT_UINT8, 3));
-		assertTrue(data.setValue(0xBEAF, Data.FORMAT_UINT16, 4));
+		assertTrue(data.setValue(0xBEAF, Data.FORMAT_UINT16_LE, 4));
 		called = false;
 		callback.onDataReceived(null, data);
 		assertTrue(called);

--- a/ble-common/src/test/java/no/nordicsemi/android/ble/common/callback/cgm/CGMSessionRunTimeDataCallbackTest.java
+++ b/ble-common/src/test/java/no/nordicsemi/android/ble/common/callback/cgm/CGMSessionRunTimeDataCallbackTest.java
@@ -59,8 +59,8 @@ public class CGMSessionRunTimeDataCallbackTest {
 			}
 		};
 		final MutableData data = new MutableData(new byte[4]);
-		assertTrue(data.setValue(2, Data.FORMAT_UINT16, 0));
-		assertTrue(data.setValue(0xC308, Data.FORMAT_UINT16, 2));
+		assertTrue(data.setValue(2, Data.FORMAT_UINT16_LE, 0));
+		assertTrue(data.setValue(0xC308, Data.FORMAT_UINT16_LE, 2));
 		called = false;
 		callback.onDataReceived(null, data);
 		assertTrue(called);
@@ -113,8 +113,8 @@ public class CGMSessionRunTimeDataCallbackTest {
 			}
 		};
 		final MutableData data = new MutableData(new byte[4]);
-		assertTrue(data.setValue(2, Data.FORMAT_UINT16, 0));
-		assertTrue(data.setValue(0xC309, Data.FORMAT_UINT16, 2));
+		assertTrue(data.setValue(2, Data.FORMAT_UINT16_LE, 0));
+		assertTrue(data.setValue(0xC309, Data.FORMAT_UINT16_LE, 2));
 		called = false;
 		callback.onDataReceived(null, data);
 		assertTrue(called);
@@ -139,7 +139,7 @@ public class CGMSessionRunTimeDataCallbackTest {
 			}
 		};
 		final MutableData data = new MutableData(new byte[3]);
-		assertTrue(data.setValue(2, Data.FORMAT_UINT16, 0));
+		assertTrue(data.setValue(2, Data.FORMAT_UINT16_LE, 0));
 		assertTrue(data.setValue(1, Data.FORMAT_UINT8, 2));
 		called = false;
 		callback.onDataReceived(null, data);

--- a/ble-common/src/test/java/no/nordicsemi/android/ble/common/callback/cgm/CGMSpecificOpsControlPointDataCallbackTest.java
+++ b/ble-common/src/test/java/no/nordicsemi/android/ble/common/callback/cgm/CGMSpecificOpsControlPointDataCallbackTest.java
@@ -208,10 +208,10 @@ public class CGMSpecificOpsControlPointDataCallbackTest {
 		final MutableData data = new MutableData(new byte[11]);
 		data.setValue(6, Data.FORMAT_UINT8, 0);
 		data.setValue(1, 2, Data.FORMAT_SFLOAT, 1);
-		data.setValue(10, Data.FORMAT_UINT16, 3);
+		data.setValue(10, Data.FORMAT_UINT16_LE, 3);
 		data.setValue(0x32, Data.FORMAT_UINT8, 5);
-		data.setValue(20, Data.FORMAT_UINT16, 6);
-		data.setValue(1, Data.FORMAT_UINT16, 8);
+		data.setValue(20, Data.FORMAT_UINT16_LE, 6);
+		data.setValue(1, Data.FORMAT_UINT16_LE, 8);
 		data.setValue(0b100, Data.FORMAT_UINT8, 10);
 
 		callback.onDataReceived(null, data);
@@ -224,12 +224,12 @@ public class CGMSpecificOpsControlPointDataCallbackTest {
 		final MutableData data = new MutableData(new byte[13]);
 		data.setValue(6, Data.FORMAT_UINT8, 0);
 		data.setValue(1, 2, Data.FORMAT_SFLOAT, 1);
-		data.setValue(10, Data.FORMAT_UINT16, 3);
+		data.setValue(10, Data.FORMAT_UINT16_LE, 3);
 		data.setValue(0x32, Data.FORMAT_UINT8, 5);
-		data.setValue(20, Data.FORMAT_UINT16, 6);
-		data.setValue(1, Data.FORMAT_UINT16, 8);
+		data.setValue(20, Data.FORMAT_UINT16_LE, 6);
+		data.setValue(1, Data.FORMAT_UINT16_LE, 8);
 		data.setValue(0b100, Data.FORMAT_UINT8, 10);
-		data.setValue(0xB2BF, Data.FORMAT_UINT16, 11);
+		data.setValue(0xB2BF, Data.FORMAT_UINT16_LE, 11);
 
 		callback.onDataReceived(null, data);
 		assertTrue(valueReceived);

--- a/ble-common/src/test/java/no/nordicsemi/android/ble/common/callback/cgm/CGMStatusDataCallbackTest.java
+++ b/ble-common/src/test/java/no/nordicsemi/android/ble/common/callback/cgm/CGMStatusDataCallbackTest.java
@@ -82,9 +82,9 @@ public class CGMStatusDataCallbackTest {
 			}
 		};
 		final MutableData data = new MutableData(new byte[7]);
-		data.setValue(5, Data.FORMAT_UINT16, 0);
-		data.setValue(0xff3f3f, Data.FORMAT_UINT24, 2); // all flags set
-		data.setValue(0xE0A7, Data.FORMAT_UINT16, 5);
+		data.setValue(5, Data.FORMAT_UINT16_LE, 0);
+		data.setValue(0xff3f3f, Data.FORMAT_UINT24_LE, 2); // all flags set
+		data.setValue(0xE0A7, Data.FORMAT_UINT16_LE, 5);
 		callback.onDataReceived(null, data);
 	}
 
@@ -130,8 +130,8 @@ public class CGMStatusDataCallbackTest {
 			}
 		};
 		final MutableData data = new MutableData(new byte[5]);
-		data.setValue(6, Data.FORMAT_UINT16, 0);
-		data.setValue(0x010101, Data.FORMAT_UINT24, 2);
+		data.setValue(6, Data.FORMAT_UINT16_LE, 0);
+		data.setValue(0x010101, Data.FORMAT_UINT24_LE, 2);
 		callback.onDataReceived(null, data);
 	}
 
@@ -155,9 +155,9 @@ public class CGMStatusDataCallbackTest {
 			}
 		};
 		final MutableData data = new MutableData(new byte[7]);
-		data.setValue(6, Data.FORMAT_UINT16, 0);
-		data.setValue(0x010101, Data.FORMAT_UINT24, 2);
-		data.setValue(0xE0A7, Data.FORMAT_UINT16, 5);
+		data.setValue(6, Data.FORMAT_UINT16_LE, 0);
+		data.setValue(0x010101, Data.FORMAT_UINT24_LE, 2);
+		data.setValue(0xE0A7, Data.FORMAT_UINT16_LE, 5);
 		called = false;
 		callback.onDataReceived(null, data);
 		assertTrue(called);
@@ -183,8 +183,8 @@ public class CGMStatusDataCallbackTest {
 			}
 		};
 		final MutableData data = new MutableData(new byte[6]);
-		data.setValue(6, Data.FORMAT_UINT16, 0);
-		data.setValue(0x010101, Data.FORMAT_UINT24, 2);
+		data.setValue(6, Data.FORMAT_UINT16_LE, 0);
+		data.setValue(0x010101, Data.FORMAT_UINT24_LE, 2);
 		data.setValue(1, Data.FORMAT_UINT8, 5);
 		called = false;
 		callback.onDataReceived(null, data);

--- a/ble-common/src/test/java/no/nordicsemi/android/ble/common/callback/cgm/ContinuousGlucoseMeasurementDataCallbackTest.java
+++ b/ble-common/src/test/java/no/nordicsemi/android/ble/common/callback/cgm/ContinuousGlucoseMeasurementDataCallbackTest.java
@@ -67,7 +67,7 @@ public class ContinuousGlucoseMeasurementDataCallbackTest {
 
 			@Override
 			public void onContinuousGlucoseMeasurementReceivedWithCrcError(@NonNull final BluetoothDevice device, @NonNull final Data data) {
-				final int expectedCrc = data.getIntValue(Data.FORMAT_UINT16, 13);
+				final int expectedCrc = data.getIntValue(Data.FORMAT_UINT16_LE, 13);
 				final int actualCrc = CRC16.MCRF4XX(data.getValue(), 0, 13);
 				assertEquals("CRC error on valid data", expectedCrc, actualCrc);
 			}
@@ -85,7 +85,7 @@ public class ContinuousGlucoseMeasurementDataCallbackTest {
 		// Glucose Concentration
 		assertTrue(data.setValue(1234, -2, Data.FORMAT_SFLOAT, 2));
 		// Time offset
-		assertTrue(data.setValue(5, Data.FORMAT_UINT16, 4));
+		assertTrue(data.setValue(5, Data.FORMAT_UINT16_LE, 4));
 		// Status
 		assertTrue(data.setByte(0x02, 6)); // Warning status: Low battery
 		assertTrue(data.setByte(0x14, 7)); // Cal/Temp status: Sensor Temperature too high / Calibration recommended
@@ -95,7 +95,7 @@ public class ContinuousGlucoseMeasurementDataCallbackTest {
 		// Quality
 		assertTrue(data.setValue(997, -1, Data.FORMAT_SFLOAT, 11));
 		// E2E CRC
-		assertTrue(data.setValue(0x3F8E, Data.FORMAT_UINT16, 13));
+		assertTrue(data.setValue(0x3F8E, Data.FORMAT_UINT16_LE, 13));
 
 		callback.onDataReceived(null, data);
 	}
@@ -133,7 +133,7 @@ public class ContinuousGlucoseMeasurementDataCallbackTest {
 		// Glucose Concentration
 		assertTrue(data.setValue(12, 1, Data.FORMAT_SFLOAT, 2));
 		// Time offset
-		assertTrue(data.setValue(6, Data.FORMAT_UINT16, 4));
+		assertTrue(data.setValue(6, Data.FORMAT_UINT16_LE, 4));
 
 		callback.onDataReceived(null, data);
 	}
@@ -173,7 +173,7 @@ public class ContinuousGlucoseMeasurementDataCallbackTest {
 		// Glucose Concentration
 		assertTrue(data.setValue(12, 1, Data.FORMAT_SFLOAT, 2));
 		// Time offset
-		assertTrue(data.setValue(5, Data.FORMAT_UINT16, 4));
+		assertTrue(data.setValue(5, Data.FORMAT_UINT16_LE, 4));
 
 		// Size
 		assertTrue(data.setValue(6, Data.FORMAT_UINT8, 6));
@@ -182,7 +182,7 @@ public class ContinuousGlucoseMeasurementDataCallbackTest {
 		// Glucose Concentration
 		assertTrue(data.setValue(12, 1, Data.FORMAT_SFLOAT, 8));
 		// Time offset
-		assertTrue(data.setValue(6, Data.FORMAT_UINT16, 10));
+		assertTrue(data.setValue(6, Data.FORMAT_UINT16_LE, 10));
 
 		callback.onDataReceived(null, data);
 	}
@@ -216,9 +216,9 @@ public class ContinuousGlucoseMeasurementDataCallbackTest {
 		// Glucose Concentration
 		assertTrue(data.setValue(12, 1, Data.FORMAT_SFLOAT, 2));
 		// Time offset
-		assertTrue(data.setValue(6, Data.FORMAT_UINT16, 4));
+		assertTrue(data.setValue(6, Data.FORMAT_UINT16_LE, 4));
 		// E2E CRC
-		assertTrue(data.setValue(0x6F58, Data.FORMAT_UINT16, 6));
+		assertTrue(data.setValue(0x6F58, Data.FORMAT_UINT16_LE, 6));
 
 		callback.onDataReceived(null, data);
 	}
@@ -251,7 +251,7 @@ public class ContinuousGlucoseMeasurementDataCallbackTest {
 		// Glucose Concentration
 		assertTrue(data.setValue(12, 1, Data.FORMAT_SFLOAT, 2));
 		// Time offset
-		assertFalse(data.setValue(6, Data.FORMAT_UINT16, 4));
+		assertFalse(data.setValue(6, Data.FORMAT_UINT16_LE, 4));
 
 		callback.onDataReceived(null, data);
 	}
@@ -284,7 +284,7 @@ public class ContinuousGlucoseMeasurementDataCallbackTest {
 		// Glucose Concentration
 		assertTrue(data.setValue(12, 1, Data.FORMAT_SFLOAT, 2));
 		// Time offset
-		assertTrue(data.setValue(6, Data.FORMAT_UINT16, 4));
+		assertTrue(data.setValue(6, Data.FORMAT_UINT16_LE, 4));
 		// Trend
 		assertFalse(data.setValue(2, -1, Data.FORMAT_SFLOAT, 9));
 

--- a/ble-common/src/test/java/no/nordicsemi/android/ble/common/callback/csc/CyclingSpeedAndCadenceMeasurementDataCallbackTest.java
+++ b/ble-common/src/test/java/no/nordicsemi/android/ble/common/callback/csc/CyclingSpeedAndCadenceMeasurementDataCallbackTest.java
@@ -66,8 +66,8 @@ public class CyclingSpeedAndCadenceMeasurementDataCallbackTest {
 		// Flags
 		assertTrue(data.setByte(0x01, 0));
 		// Wheel revolutions
-		assertTrue(data.setValue(12345, Data.FORMAT_UINT32, 1));
-		assertTrue(data.setValue(1000, Data.FORMAT_UINT16, 5));
+		assertTrue(data.setValue(12345, Data.FORMAT_UINT32_LE, 1));
+		assertTrue(data.setValue(1000, Data.FORMAT_UINT16_LE, 5));
 
 		callback.onDataReceived(null, data);
 	}
@@ -100,8 +100,8 @@ public class CyclingSpeedAndCadenceMeasurementDataCallbackTest {
 		// Flags
 		assertTrue(data.setByte(0x02, 0));
 		// Crank revolutions
-		assertTrue(data.setValue(345, Data.FORMAT_UINT16, 1));
-		assertTrue(data.setValue(2000, Data.FORMAT_UINT16, 3));
+		assertTrue(data.setValue(345, Data.FORMAT_UINT16_LE, 1));
+		assertTrue(data.setValue(2000, Data.FORMAT_UINT16_LE, 3));
 
 		callback.onDataReceived(null, data);
 	}
@@ -140,11 +140,11 @@ public class CyclingSpeedAndCadenceMeasurementDataCallbackTest {
 		// Flags
 		assertTrue(data.setByte(0x03, 0));
 		// Wheel revolutions
-		assertTrue(data.setValue(12345, Data.FORMAT_UINT32, 1));
-		assertTrue(data.setValue(1000, Data.FORMAT_UINT16, 5));
+		assertTrue(data.setValue(12345, Data.FORMAT_UINT32_LE, 1));
+		assertTrue(data.setValue(1000, Data.FORMAT_UINT16_LE, 5));
 		// Crank revolutions
-		assertTrue(data.setValue(345, Data.FORMAT_UINT16, 7));
-		assertTrue(data.setValue(2000, Data.FORMAT_UINT16, 9));
+		assertTrue(data.setValue(345, Data.FORMAT_UINT16_LE, 7));
+		assertTrue(data.setValue(2000, Data.FORMAT_UINT16_LE, 9));
 
 		callback.onDataReceived(null, data);
 	}
@@ -173,14 +173,14 @@ public class CyclingSpeedAndCadenceMeasurementDataCallbackTest {
 		// Flags
 		assertTrue(data.setByte(0x01, 0));
 		// Wheel revolutions
-		assertTrue(data.setValue(10, Data.FORMAT_UINT32, 1));
-		assertTrue(data.setValue(0, Data.FORMAT_UINT16, 5));
+		assertTrue(data.setValue(10, Data.FORMAT_UINT32_LE, 1));
+		assertTrue(data.setValue(0, Data.FORMAT_UINT16_LE, 5));
 
 		callback.onDataReceived(null, data);
 
 		// Update wheel revolutions
-		assertTrue(data.setValue(20, Data.FORMAT_UINT32, 1));
-		assertTrue(data.setValue(1024, Data.FORMAT_UINT16, 5)); // 1 second
+		assertTrue(data.setValue(20, Data.FORMAT_UINT32_LE, 1));
+		assertTrue(data.setValue(1024, Data.FORMAT_UINT16_LE, 5)); // 1 second
 		callback.onDataReceived(null, data);
 	}
 
@@ -207,14 +207,14 @@ public class CyclingSpeedAndCadenceMeasurementDataCallbackTest {
 		// Flags
 		assertTrue(data.setByte(0x02, 0));
 		// Crank revolutions
-		assertTrue(data.setValue(10, Data.FORMAT_UINT16, 1));
-		assertTrue(data.setValue(0, Data.FORMAT_UINT16, 3));
+		assertTrue(data.setValue(10, Data.FORMAT_UINT16_LE, 1));
+		assertTrue(data.setValue(0, Data.FORMAT_UINT16_LE, 3));
 
 		callback.onDataReceived(null, data);
 
 		// Update crank revolutions
-		assertTrue(data.setValue(11, Data.FORMAT_UINT16, 1));
-		assertTrue(data.setValue(1024, Data.FORMAT_UINT16, 3)); // 1 second
+		assertTrue(data.setValue(11, Data.FORMAT_UINT16_LE, 1));
+		assertTrue(data.setValue(1024, Data.FORMAT_UINT16_LE, 3)); // 1 second
 		callback.onDataReceived(null, data);
 	}
 
@@ -243,20 +243,20 @@ public class CyclingSpeedAndCadenceMeasurementDataCallbackTest {
 		// Flags
 		assertTrue(data.setByte(0x03, 0));
 		// Wheel revolutions
-		assertTrue(data.setValue(20, Data.FORMAT_UINT32, 1));
-		assertTrue(data.setValue(0, Data.FORMAT_UINT16, 5));
+		assertTrue(data.setValue(20, Data.FORMAT_UINT32_LE, 1));
+		assertTrue(data.setValue(0, Data.FORMAT_UINT16_LE, 5));
 		// Crank revolutions
-		assertTrue(data.setValue(10, Data.FORMAT_UINT16, 7));
-		assertTrue(data.setValue(0, Data.FORMAT_UINT16, 9));
+		assertTrue(data.setValue(10, Data.FORMAT_UINT16_LE, 7));
+		assertTrue(data.setValue(0, Data.FORMAT_UINT16_LE, 9));
 
 		callback.onDataReceived(null, data);
 
 		// Update wheel revolutions
-		assertTrue(data.setValue(30, Data.FORMAT_UINT32, 1));
-		assertTrue(data.setValue(1024, Data.FORMAT_UINT16, 5)); // 1 second
+		assertTrue(data.setValue(30, Data.FORMAT_UINT32_LE, 1));
+		assertTrue(data.setValue(1024, Data.FORMAT_UINT16_LE, 5)); // 1 second
 		// Update crank revolutions
-		assertTrue(data.setValue(11, Data.FORMAT_UINT16, 7));
-		assertTrue(data.setValue(1024, Data.FORMAT_UINT16, 9)); // 1 second
+		assertTrue(data.setValue(11, Data.FORMAT_UINT16_LE, 7));
+		assertTrue(data.setValue(1024, Data.FORMAT_UINT16_LE, 9)); // 1 second
 		callback.onDataReceived(null, data);
 	}
 
@@ -282,11 +282,11 @@ public class CyclingSpeedAndCadenceMeasurementDataCallbackTest {
 		// Flags
 		assertTrue(data.setByte(0x03, 0));
 		// Wheel revolutions
-		assertTrue(data.setValue(20, Data.FORMAT_UINT32, 1));
-		assertTrue(data.setValue(0, Data.FORMAT_UINT16, 5));
+		assertTrue(data.setValue(20, Data.FORMAT_UINT32_LE, 1));
+		assertTrue(data.setValue(0, Data.FORMAT_UINT16_LE, 5));
 		// Crank revolutions
-		assertTrue(data.setValue(10, Data.FORMAT_UINT16, 7));
-		assertFalse(data.setValue(0, Data.FORMAT_UINT16, 9));
+		assertTrue(data.setValue(10, Data.FORMAT_UINT16_LE, 7));
+		assertFalse(data.setValue(0, Data.FORMAT_UINT16_LE, 9));
 
 		callback.onDataReceived(null, data);
 	}

--- a/ble-common/src/test/java/no/nordicsemi/android/ble/common/callback/glucose/GlucoseMeasurementContextDataCallbackTest.java
+++ b/ble-common/src/test/java/no/nordicsemi/android/ble/common/callback/glucose/GlucoseMeasurementContextDataCallbackTest.java
@@ -101,13 +101,13 @@ public class GlucoseMeasurementContextDataCallbackTest {
 	public void onGlucoseMeasurementContextReceived_full() {
 		final MutableData data = new MutableData(new byte[17]);
 		data.setValue(0xFF, Data.FORMAT_UINT8, 0); // Flags
-		data.setValue(0, Data.FORMAT_UINT16, 1); // Sequence number
+		data.setValue(0, Data.FORMAT_UINT16_LE, 1); // Sequence number
 		data.setValue(0xb3, Data.FORMAT_UINT8, 3); // Extended flags - ignored
 		data.setValue(GlucoseMeasurementContextCallback.Carbohydrate.DINNER.value, Data.FORMAT_UINT8, 4); // Carbohydrate
 		data.setValue(100.0f, Data.FORMAT_SFLOAT, 5); // Carbohydrate Amount
 		data.setValue(GlucoseMeasurementContextCallback.Meal.CASUAL.value, Data.FORMAT_UINT8, 7); // Meal
 		data.setValue(0x12, Data.FORMAT_UINT8, 8); // Tester and Health (health care practitioner, minor issues)
-		data.setValue(60, Data.FORMAT_UINT16, 9); // 1 minute of exercise
+		data.setValue(60, Data.FORMAT_UINT16_LE, 9); // 1 minute of exercise
 		data.setValue(50, Data.FORMAT_UINT8, 11); // 50%
 		data.setValue(4, Data.FORMAT_UINT8, 12); // Long acting insulin
 		data.setValue(123.45f, Data.FORMAT_SFLOAT, 13); // 123.45 ml
@@ -121,7 +121,7 @@ public class GlucoseMeasurementContextDataCallbackTest {
 	public void onGlucoseMeasurementContextReceived_empty() {
 		final MutableData data = new MutableData(new byte[17]);
 		data.setValue(0x00, Data.FORMAT_UINT8, 0); // Flags
-		data.setValue(1, Data.FORMAT_UINT16, 1);
+		data.setValue(1, Data.FORMAT_UINT16_LE, 1);
 		callback.onDataReceived(null, data);
 		assertTrue(success);
 		assertEquals(1, number);
@@ -131,13 +131,13 @@ public class GlucoseMeasurementContextDataCallbackTest {
 	public void onInvalidDataReceived() {
 		final MutableData data = new MutableData(new byte[5]);
 		data.setValue(0xFF, Data.FORMAT_UINT8, 0); // Flags
-		data.setValue(0, Data.FORMAT_UINT16, 1); // Sequence number
+		data.setValue(0, Data.FORMAT_UINT16_LE, 1); // Sequence number
 		data.setValue(0xb3, Data.FORMAT_UINT8, 3); // Extended flags - ignored
 		data.setValue(3, Data.FORMAT_UINT8, 4); // Carbohydrate: dinner
 		data.setValue(100.0f, Data.FORMAT_SFLOAT, 5); // Carbohydrate Amount
 		data.setValue(4, Data.FORMAT_UINT8, 7); // Meal: casual
 		data.setValue(0x12, Data.FORMAT_UINT8, 8); // Tester and Health (health care practitioner, minor issues)
-		data.setValue(60, Data.FORMAT_UINT16, 9); // 1 minute of exercise
+		data.setValue(60, Data.FORMAT_UINT16_LE, 9); // 1 minute of exercise
 		data.setValue(50, Data.FORMAT_UINT8, 11); // 50%
 		data.setValue(4, Data.FORMAT_UINT8, 12); // Long acting insulin
 		data.setValue(123.45f, Data.FORMAT_SFLOAT, 13); // 123.45 ml

--- a/ble-common/src/test/java/no/nordicsemi/android/ble/common/callback/rsc/RunningSpeedAndCadenceMeasurementDataCallbackTest.java
+++ b/ble-common/src/test/java/no/nordicsemi/android/ble/common/callback/rsc/RunningSpeedAndCadenceMeasurementDataCallbackTest.java
@@ -66,10 +66,10 @@ public class RunningSpeedAndCadenceMeasurementDataCallbackTest {
 
 		final MutableData data = new MutableData(new byte[10]);
 		data.setByte(0x7, 0);
-		data.setValue(3 * 256, Data.FORMAT_UINT16, 1);
+		data.setValue(3 * 256, Data.FORMAT_UINT16_LE, 1);
 		data.setValue(18, Data.FORMAT_UINT8, 3);
-		data.setValue(86, Data.FORMAT_UINT16, 4);
-		data.setValue(0xF0000001L, Data.FORMAT_UINT32, 6);
+		data.setValue(86, Data.FORMAT_UINT16_LE, 4);
+		data.setValue(0xF0000001L, Data.FORMAT_UINT32_LE, 6);
 		called = false;
 		response.onDataReceived(null, data);
 		assertTrue(response.isValid());
@@ -97,10 +97,10 @@ public class RunningSpeedAndCadenceMeasurementDataCallbackTest {
 
 		final MutableData data = new MutableData(new byte[9]); // too short
 		data.setByte(0x7, 0);
-		data.setValue(3 * 256, Data.FORMAT_UINT16, 1);
+		data.setValue(3 * 256, Data.FORMAT_UINT16_LE, 1);
 		data.setValue(18, Data.FORMAT_UINT8, 3);
-		data.setValue(86, Data.FORMAT_UINT16, 4);
-		data.setValue(0, Data.FORMAT_UINT24, 6);
+		data.setValue(86, Data.FORMAT_UINT16_LE, 4);
+		data.setValue(0, Data.FORMAT_UINT24_LE, 6);
 		called = false;
 		invalidData = false;
 		response.onDataReceived(null, data);

--- a/ble/src/main/java/no/nordicsemi/android/ble/data/Data.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/data/Data.java
@@ -22,6 +22,7 @@
 
 package no.nordicsemi.android.ble.data;
 
+import android.annotation.SuppressLint;
 import android.bluetooth.BluetoothGattCharacteristic;
 import android.bluetooth.BluetoothGattDescriptor;
 import android.os.Parcel;
@@ -37,20 +38,29 @@ import androidx.annotation.Nullable;
 
 @SuppressWarnings({"WeakerAccess", "unused", "UnusedReturnValue"})
 public class Data implements Parcelable {
+
+	@SuppressWarnings("deprecation")
+	@SuppressLint("UniqueConstants")
 	@Retention(RetentionPolicy.SOURCE)
 	@IntDef(value = {
 			FORMAT_UINT8,
+			FORMAT_UINT16,
 			FORMAT_UINT16_LE,
 			FORMAT_UINT16_BE,
+			FORMAT_UINT24,
 			FORMAT_UINT24_LE,
 			FORMAT_UINT24_BE,
+			FORMAT_UINT32,
 			FORMAT_UINT32_LE,
 			FORMAT_UINT32_BE,
 			FORMAT_SINT8,
+			FORMAT_SINT16,
 			FORMAT_SINT16_LE,
 			FORMAT_SINT16_BE,
+			FORMAT_SINT24,
 			FORMAT_SINT24_LE,
 			FORMAT_SINT24_BE,
+			FORMAT_SINT32,
 			FORMAT_SINT32_LE,
 			FORMAT_SINT32_BE,
 			FORMAT_FLOAT,
@@ -58,29 +68,41 @@ public class Data implements Parcelable {
 	})
 	public @interface ValueFormat {}
 
+	@SuppressWarnings("deprecation")
+	@SuppressLint("UniqueConstants")
 	@Retention(RetentionPolicy.SOURCE)
 	@IntDef(value = {
 			FORMAT_UINT8,
+			FORMAT_UINT16,
 			FORMAT_UINT16_LE,
 			FORMAT_UINT16_BE,
+			FORMAT_UINT24,
 			FORMAT_UINT24_LE,
 			FORMAT_UINT24_BE,
+			FORMAT_UINT32,
 			FORMAT_UINT32_LE,
 			FORMAT_UINT32_BE,
 			FORMAT_SINT8,
+			FORMAT_SINT16,
 			FORMAT_SINT16_LE,
 			FORMAT_SINT16_BE,
+			FORMAT_SINT24,
 			FORMAT_SINT24_LE,
 			FORMAT_SINT24_BE,
+			FORMAT_SINT32,
 			FORMAT_SINT32_LE,
 			FORMAT_SINT32_BE,
 	})
 	public @interface IntFormat {}
 
+	@SuppressWarnings("deprecation")
+	@SuppressLint("UniqueConstants")
 	@Retention(RetentionPolicy.SOURCE)
 	@IntDef(value = {
+			FORMAT_UINT32,
 			FORMAT_UINT32_LE,
 			FORMAT_UINT32_BE,
+			FORMAT_SINT32,
 			FORMAT_SINT32_LE,
 			FORMAT_SINT32_BE,
 	})
@@ -103,6 +125,8 @@ public class Data implements Parcelable {
 	/**
 	 * Data value format type uint16
 	 */
+	@SuppressWarnings("DeprecatedIsStillUsed")
+	@Deprecated
 	public final static int FORMAT_UINT16 = 0x12;
 	public final static int FORMAT_UINT16_LE = 0x12;
 	public final static int FORMAT_UINT16_BE = 0x112;
@@ -110,6 +134,8 @@ public class Data implements Parcelable {
 	/**
 	 * Data value format type uint24
 	 */
+	@SuppressWarnings("DeprecatedIsStillUsed")
+	@Deprecated
 	public final static int FORMAT_UINT24 = 0x13;
 	public final static int FORMAT_UINT24_LE = 0x13;
 	public final static int FORMAT_UINT24_BE = 0x113;
@@ -117,6 +143,8 @@ public class Data implements Parcelable {
 	/**
 	 * Data value format type uint32
 	 */
+	@SuppressWarnings("DeprecatedIsStillUsed")
+	@Deprecated
 	public final static int FORMAT_UINT32 = 0x14;
 	public final static int FORMAT_UINT32_LE = 0x14;
 	public final static int FORMAT_UINT32_BE = 0x114;
@@ -129,6 +157,8 @@ public class Data implements Parcelable {
 	/**
 	 * Data value format type sint16
 	 */
+	@SuppressWarnings("DeprecatedIsStillUsed")
+	@Deprecated
 	public final static int FORMAT_SINT16 = 0x22;
 	public final static int FORMAT_SINT16_LE = 0x22;
 	public final static int FORMAT_SINT16_BE = 0x122;
@@ -136,6 +166,8 @@ public class Data implements Parcelable {
 	/**
 	 * Data value format type sint24
 	 */
+	@SuppressWarnings("DeprecatedIsStillUsed")
+	@Deprecated
 	public final static int FORMAT_SINT24 = 0x23;
 	public final static int FORMAT_SINT24_LE = 0x23;
 	public final static int FORMAT_SINT24_BE = 0x123;
@@ -143,6 +175,8 @@ public class Data implements Parcelable {
 	/**
 	 * Data value format type sint32
 	 */
+	@SuppressWarnings("DeprecatedIsStillUsed")
+	@Deprecated
 	public final static int FORMAT_SINT32 = 0x24;
 	public final static int FORMAT_SINT32_LE = 0x24;
 	public final static int FORMAT_SINT32_BE = 0x124;
@@ -258,7 +292,7 @@ public class Data implements Parcelable {
 	 * <p>
 	 * <p>The formatType parameter determines how the value
 	 * is to be interpreted. For example, setting formatType to
-	 * {@link #FORMAT_UINT16} specifies that the first two bytes of the
+	 * {@link #FORMAT_UINT16_LE} specifies that the first two bytes of the
 	 * value at the given offset are interpreted to generate the
 	 * return value.
 	 *
@@ -356,10 +390,10 @@ public class Data implements Parcelable {
 
 	/**
 	 * Returns a long value from the byte array.
-	 * <p>Only {@link #FORMAT_UINT32} and {@link #FORMAT_SINT32} are supported.
+	 * <p>Only {@link #FORMAT_UINT32_LE} and {@link #FORMAT_SINT32_LE} are supported.
 	 * <p>The formatType parameter determines how the value
 	 * is to be interpreted. For example, setting formatType to
-	 * {@link #FORMAT_UINT32} specifies that the first four bytes of the
+	 * {@link #FORMAT_UINT32_LE} specifies that the first four bytes of the
 	 * value at the given offset are interpreted to generate the
 	 * return value.
 	 *
@@ -533,9 +567,10 @@ public class Data implements Parcelable {
 	 * Convert an unsigned long value to a two's-complement encoded
 	 * signed value.
 	 */
+	@SuppressWarnings("SameParameterValue")
 	private static long unsignedToSigned(long unsigned, final int size) {
-		if ((unsigned & (1 << size - 1)) != 0) {
-			unsigned = -1 * ((1 << size - 1) - (unsigned & ((1 << size - 1) - 1)));
+		if ((unsigned & (1L << size - 1)) != 0) {
+			unsigned = -1 * ((1L << size - 1) - (unsigned & ((1L << size - 1) - 1)));
 		}
 		return unsigned;
 	}

--- a/ble/src/main/java/no/nordicsemi/android/ble/data/MutableData.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/data/MutableData.java
@@ -228,7 +228,7 @@ public class MutableData extends Data {
 	 * Set the locally stored value of this data.
 	 * <p>See {@link #setValue(byte[])} for details.
 	 *
-	 * @param value      New value for this data. This allows to send {@link #FORMAT_UINT32}.
+	 * @param value      New value for this data. This allows to send {@link #FORMAT_UINT32_LE}.
 	 * @param formatType Integer format type used to transform the value parameter
 	 * @param offset     Offset at which the value should be placed
 	 * @return true if the locally stored value has been set

--- a/ble/src/test/java/no/nordicsemi/android/ble/data/DataStreamTest.java
+++ b/ble/src/test/java/no/nordicsemi/android/ble/data/DataStreamTest.java
@@ -67,6 +67,6 @@ public class DataStreamTest {
 		final DataStream stream = new DataStream();
 		stream.write(new byte[] { 0, 1, 2, 3, 4, 5, 6});
 		final Data data = stream.toData();
-		assertEquals(0x100, data.getIntValue(Data.FORMAT_UINT16, 0).intValue());
+		assertEquals(0x100, data.getIntValue(Data.FORMAT_UINT16_LE, 0).intValue());
 	}
 }

--- a/ble/src/test/java/no/nordicsemi/android/ble/data/DataTest.java
+++ b/ble/src/test/java/no/nordicsemi/android/ble/data/DataTest.java
@@ -186,7 +186,7 @@ public class DataTest {
 	@Test
 	public void setValue_UINT16() {
 		final MutableData data = new MutableData(new byte[2]);
-		data.setValue(26576, Data.FORMAT_UINT16, 0);
+		data.setValue(26576, Data.FORMAT_UINT16_LE, 0);
 		assertArrayEquals(new byte[] { (byte) 0xD0, 0x67 } , data.getValue());
 	}
 
@@ -200,7 +200,7 @@ public class DataTest {
 	@Test
 	public void getValue_UINT16() {
 		final Data data = new Data(new byte[] { (byte) 0xD0, 0x67 });
-		final int value = data.getIntValue(Data.FORMAT_UINT16, 0);
+		final int value = data.getIntValue(Data.FORMAT_UINT16_LE, 0);
 		assertEquals(26576, value);
 	}
 
@@ -214,7 +214,7 @@ public class DataTest {
 	@Test
 	public void setValue_SINT16() {
 		final MutableData data = new MutableData(new byte[2]);
-		data.setValue(-6192, Data.FORMAT_SINT16, 0);
+		data.setValue(-6192, Data.FORMAT_SINT16_LE, 0);
 		assertArrayEquals(new byte[] { (byte) 0xD0, (byte) 0xE7 } , data.getValue());
 	}
 
@@ -228,7 +228,7 @@ public class DataTest {
 	@Test
 	public void getValue_SINT16() {
 		final Data data = new Data(new byte[] { (byte) 0xD0, (byte) 0xE7 });
-		final int value = data.getIntValue(Data.FORMAT_SINT16, 0);
+		final int value = data.getIntValue(Data.FORMAT_SINT16_LE, 0);
 		assertEquals(-6192, value);
 	}
 
@@ -242,7 +242,7 @@ public class DataTest {
 	@Test
 	public void setValue_UINT24() {
 		final MutableData data = new MutableData(new byte[3]);
-		data.setValue(0x010203, Data.FORMAT_UINT24, 0);
+		data.setValue(0x010203, Data.FORMAT_UINT24_LE, 0);
 		assertArrayEquals(new byte[] { 0x03, 0x02, 0x01 } , data.getValue());
 	}
 
@@ -256,7 +256,7 @@ public class DataTest {
 	@Test
 	public void getValue_UINT24() {
 		final Data data = new Data(new byte[] { 0x03, 0x02, 0x01 });
-		final int value = data.getIntValue(Data.FORMAT_UINT24, 0);
+		final int value = data.getIntValue(Data.FORMAT_UINT24_LE, 0);
 		assertEquals(0x010203, value);
 	}
 
@@ -270,7 +270,7 @@ public class DataTest {
 	@Test
 	public void setValue_SINT24() {
 		final MutableData data = new MutableData(new byte[3]);
-		data.setValue(0xfefdfd, Data.FORMAT_UINT24, 0);
+		data.setValue(0xfefdfd, Data.FORMAT_UINT24_LE, 0);
 		assertArrayEquals(new byte[] { (byte) 0xFD, (byte) 0xFD, (byte) 0xFE } , data.getValue());
 	}
 
@@ -284,7 +284,7 @@ public class DataTest {
 	@Test
 	public void getValue_SINT24() {
 		final MutableData data = new MutableData(new byte[] { (byte) 0xFD, (byte) 0xFD, (byte) 0xFE });
-		final int value = data.getIntValue(Data.FORMAT_UINT24, 0);
+		final int value = data.getIntValue(Data.FORMAT_UINT24_LE, 0);
 		assertEquals(0xfefdfd, value);
 	}
 
@@ -298,7 +298,7 @@ public class DataTest {
 	@Test
 	public void setValue_UINT32() {
 		final MutableData data = new MutableData(new byte[4]);
-		data.setValue(0x01020304, Data.FORMAT_UINT32, 0);
+		data.setValue(0x01020304, Data.FORMAT_UINT32_LE, 0);
 		assertArrayEquals(new byte[] { 0x04, 0x03, 0x02, 0x01 } , data.getValue());
 	}
 
@@ -312,7 +312,7 @@ public class DataTest {
 	@Test
 	public void getValue_UINT32() {
 		final Data data = new Data(new byte[] { 0x04, 0x03, 0x02, 0x01 });
-		final int value = data.getIntValue(Data.FORMAT_UINT32, 0);
+		final int value = data.getIntValue(Data.FORMAT_UINT32_LE, 0);
 		assertEquals(0x01020304, value);
 	}
 
@@ -326,7 +326,7 @@ public class DataTest {
 	@Test
 	public void setValue_SINT32() {
 		final MutableData data = new MutableData(new byte[4]);
-		data.setValue(0xfefdfd00, Data.FORMAT_UINT32, 0);
+		data.setValue(0xfefdfd00, Data.FORMAT_UINT32_LE, 0);
 		assertArrayEquals(new byte[] { (byte) 0x00, (byte) 0xFD, (byte) 0xFD, (byte) 0xFE } , data.getValue());
 	}
 
@@ -340,7 +340,7 @@ public class DataTest {
 	@Test
 	public void getValue_SINT32() {
 		final Data data = new Data(new byte[] { (byte) 0x00, (byte) 0xFD, (byte) 0xFD, (byte) 0xFE });
-		final int value = data.getIntValue(Data.FORMAT_UINT32, 0);
+		final int value = data.getIntValue(Data.FORMAT_UINT32_LE, 0);
 		assertEquals(0xfefdfd00, value);
 	}
 
@@ -354,7 +354,7 @@ public class DataTest {
 	@Test
 	public void setValue_UINT32_big() {
 		final MutableData data = new MutableData(new byte[4]);
-		data.setValue(0xF0000001L, Data.FORMAT_UINT32, 0);
+		data.setValue(0xF0000001L, Data.FORMAT_UINT32_LE, 0);
 		assertArrayEquals(new byte[] { 0x01, 0x00, 0x00, (byte) 0xF0 } , data.getValue());
 	}
 
@@ -368,7 +368,7 @@ public class DataTest {
 	@Test
 	public void getValue_UINT32_big() {
 		final Data data = new Data(new byte[] { 0x01, 0x00, 0x00, (byte) 0xF0 });
-		final long value = data.getLongValue(Data.FORMAT_UINT32, 0);
+		final long value = data.getLongValue(Data.FORMAT_UINT32_LE, 0);
 		assertEquals(0xF0000001L, value);
 	}
 


### PR DESCRIPTION
This PR is a continuation of #352, in which the old format types are marked as deprecated, in favor of formats ending with `_LE`.
E.g. `FORMAT_UINT16` has been renamed to `FORMAT_UINT16_LE`.

This PR reformats the code of the library to use the new constants.