### PR TITLE
Filtering merged packets

### DIFF
--- a/ble/src/main/java/no/nordicsemi/android/ble/BleManagerHandler.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/BleManagerHandler.java
@@ -2357,7 +2357,7 @@ abstract class BleManagerHandler extends RequestHandler {
 					valueChangedRequest.notifyValueChanged(gatt.getDevice(), data);
 
 					// If no more data are expected
-					if (!valueChangedRequest.hasMore()) {
+					if (valueChangedRequest.isComplete()) {
 						// notify success,
 						valueChangedRequest.notifySuccess(gatt.getDevice());
 						// and proceed to the next request only if the trigger has completed.
@@ -2871,7 +2871,7 @@ abstract class BleManagerHandler extends RequestHandler {
 				waitForWrite.notifyValueChanged(device, value);
 
 				// If no more data are expected
-				if (!waitForWrite.hasMore()) {
+				if (waitForWrite.isComplete()) {
 					// notify success,
 					waitForWrite.notifySuccess(device);
 					// and proceed to the next request only if the trigger has completed.
@@ -2913,7 +2913,7 @@ abstract class BleManagerHandler extends RequestHandler {
 				waitForWrite.notifyValueChanged(device, value);
 
 				// If no more data are expected
-				if (!waitForWrite.hasMore()) {
+				if (waitForWrite.isComplete()) {
 					// notify success,
 					waitForWrite.notifySuccess(device);
 					// and proceed to the next request only if the trigger has completed.

--- a/ble/src/main/java/no/nordicsemi/android/ble/BleManagerHandler.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/BleManagerHandler.java
@@ -1768,8 +1768,8 @@ abstract class BleManagerHandler extends RequestHandler {
 	private final BluetoothGattCallback gattCallback = new BluetoothGattCallback() {
 
 		@Override
-		public final void onConnectionStateChange(@NonNull final BluetoothGatt gatt,
-												  final int status, final int newState) {
+		public void onConnectionStateChange(@NonNull final BluetoothGatt gatt,
+											final int status, final int newState) {
 			log(Log.DEBUG, () ->
 					"[Callback] Connection state changed with status: " + status +
 					" and new state: " + newState + " (" + ParserUtils.stateToString(newState) + ")");
@@ -1925,7 +1925,7 @@ abstract class BleManagerHandler extends RequestHandler {
 		}
 
 		@Override
-		public final void onServicesDiscovered(@NonNull final BluetoothGatt gatt, final int status) {
+		public void onServicesDiscovered(@NonNull final BluetoothGatt gatt, final int status) {
 			if (!serviceDiscoveryRequested)
 				return;
 			serviceDiscoveryRequested = false;
@@ -2046,7 +2046,7 @@ abstract class BleManagerHandler extends RequestHandler {
 		 * Requires API 31+.
 		 */
 		@Keep
-		public final void onServiceChanged(@NonNull final BluetoothGatt gatt) {
+		public void onServiceChanged(@NonNull final BluetoothGatt gatt) {
 			log(Log.INFO, () -> "Service changed, invalidating services");
 
 			// Forbid enqueuing more operations.
@@ -2163,8 +2163,8 @@ abstract class BleManagerHandler extends RequestHandler {
 		}
 
 		@Override
-		public final void onReliableWriteCompleted(@NonNull final BluetoothGatt gatt,
-												   final int status) {
+		public void onReliableWriteCompleted(@NonNull final BluetoothGatt gatt,
+											 final int status) {
 			final boolean execute = request.type == Request.Type.EXECUTE_RELIABLE_WRITE;
 			reliableWriteInProgress = false;
 			if (status == BluetoothGatt.GATT_SUCCESS) {
@@ -2377,9 +2377,9 @@ abstract class BleManagerHandler extends RequestHandler {
 
 		@RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
 		@Override
-		public final void onMtuChanged(@NonNull final BluetoothGatt gatt,
-									   @IntRange(from = 23, to = 517) final int mtu,
-									   final int status) {
+		public void onMtuChanged(@NonNull final BluetoothGatt gatt,
+								 @IntRange(from = 23, to = 517) final int mtu,
+								 final int status) {
 			if (status == BluetoothGatt.GATT_SUCCESS) {
 				log(Log.INFO, () -> "MTU changed to: " + mtu);
 				BleManagerHandler.this.mtu = mtu;
@@ -2422,11 +2422,11 @@ abstract class BleManagerHandler extends RequestHandler {
 		 */
 		@RequiresApi(api = Build.VERSION_CODES.O)
 		// @Override
-		public final void onConnectionUpdated(@NonNull final BluetoothGatt gatt,
-											  @IntRange(from = 6, to = 3200) final int interval,
-											  @IntRange(from = 0, to = 499) final int latency,
-											  @IntRange(from = 10, to = 3200) final int timeout,
-											  final int status) {
+		public void onConnectionUpdated(@NonNull final BluetoothGatt gatt,
+										@IntRange(from = 6, to = 3200) final int interval,
+										@IntRange(from = 0, to = 499) final int latency,
+										@IntRange(from = 10, to = 3200) final int timeout,
+										final int status) {
 			if (status == BluetoothGatt.GATT_SUCCESS) {
 				log(Log.INFO, () ->
 						"Connection parameters updated " +
@@ -2477,9 +2477,9 @@ abstract class BleManagerHandler extends RequestHandler {
 
 		@RequiresApi(api = Build.VERSION_CODES.O)
 		@Override
-		public final void onPhyUpdate(@NonNull final BluetoothGatt gatt,
-									  @PhyValue final int txPhy, @PhyValue final int rxPhy,
-									  final int status) {
+		public void onPhyUpdate(@NonNull final BluetoothGatt gatt,
+								@PhyValue final int txPhy, @PhyValue final int rxPhy,
+								final int status) {
 			if (status == BluetoothGatt.GATT_SUCCESS) {
 				log(Log.INFO, () ->
 						"PHY updated (TX: " + ParserUtils.phyToString(txPhy) +
@@ -2505,9 +2505,9 @@ abstract class BleManagerHandler extends RequestHandler {
 
 		@RequiresApi(api = Build.VERSION_CODES.O)
 		@Override
-		public final void onPhyRead(@NonNull final BluetoothGatt gatt,
-									@PhyValue final int txPhy, @PhyValue final int rxPhy,
-									final int status) {
+		public void onPhyRead(@NonNull final BluetoothGatt gatt,
+							  @PhyValue final int txPhy, @PhyValue final int rxPhy,
+							  final int status) {
 			if (status == BluetoothGatt.GATT_SUCCESS) {
 				log(Log.INFO, () ->
 						"PHY read (TX: " + ParserUtils.phyToString(txPhy) +
@@ -2529,9 +2529,9 @@ abstract class BleManagerHandler extends RequestHandler {
 		}
 
 		@Override
-		public final void onReadRemoteRssi(@NonNull final BluetoothGatt gatt,
-										   @IntRange(from = -128, to = 20) final int rssi,
-										   final int status) {
+		public void onReadRemoteRssi(@NonNull final BluetoothGatt gatt,
+									 @IntRange(from = -128, to = 20) final int rssi,
+									 final int status) {
 			if (status == BluetoothGatt.GATT_SUCCESS) {
 				log(Log.INFO, () -> "Remote RSSI received: " + rssi + " dBm");
 				if (request instanceof ReadRssiRequest) {

--- a/ble/src/main/java/no/nordicsemi/android/ble/ValueChangedCallback.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/ValueChangedCallback.java
@@ -33,6 +33,7 @@ import no.nordicsemi.android.ble.data.Data;
 import no.nordicsemi.android.ble.data.DataFilter;
 import no.nordicsemi.android.ble.data.DataMerger;
 import no.nordicsemi.android.ble.data.DataStream;
+import no.nordicsemi.android.ble.data.PacketFilter;
 
 @SuppressWarnings({"unused", "UnusedReturnValue"})
 public class ValueChangedCallback {
@@ -41,6 +42,7 @@ public class ValueChangedCallback {
 	private DataMerger dataMerger;
 	private DataStream buffer;
 	private DataFilter filter;
+	private PacketFilter packetFilter;
 	private CallbackHandler handler;
 	private int count = 0;
 
@@ -84,6 +86,9 @@ public class ValueChangedCallback {
 
 	/**
 	 * Sets a filter which allows to skip some incoming data.
+	 * <p>
+	 * This filter filters each received packet before they are given to the data merger.
+	 * To filter the complete packet after merging, use {@link #filterPacket(PacketFilter)} instead.
 	 *
 	 * @param filter the data filter.
 	 * @return The request.
@@ -91,6 +96,23 @@ public class ValueChangedCallback {
 	@NonNull
 	public ValueChangedCallback filter(@NonNull final DataFilter filter) {
 		this.filter = filter;
+		return this;
+	}
+
+	/**
+	 * Sets a packet filter which allows to ignore the complete packet.
+	 * <p>
+	 * This filter differs from the {@link #filter(DataFilter)}, as it checks the complete
+	 * packet, after it has been merged. If there is not merger set, this does the same as
+	 * the data filter.
+	 *
+	 * @param filter the packet filter.
+	 * @since 2.4.0
+	 * @return The request.
+	 */
+	@NonNull
+	public ValueChangedCallback filterPacket(@NonNull final PacketFilter filter) {
+		this.packetFilter = filter;
 		return this;
 	}
 
@@ -142,7 +164,7 @@ public class ValueChangedCallback {
 			return;
 		}
 
-		if (dataMerger == null) {
+		if (dataMerger == null && (packetFilter == null || packetFilter.filter(value))) {
 			final Data data = new Data(value);
 			handler.post(() -> valueCallback.onDataReceived(device, data));
 		} else {
@@ -153,8 +175,11 @@ public class ValueChangedCallback {
 			if (buffer == null)
 				buffer = new DataStream();
 			if (dataMerger.merge(buffer, value, count++)) {
-				final Data data = buffer.toData();
-				handler.post(() -> valueCallback.onDataReceived(device, data));
+				final byte[] merged = buffer.toByteArray();
+				if (packetFilter == null || packetFilter.filter(merged)) {
+					final Data data = new Data(merged);
+					handler.post(() -> valueCallback.onDataReceived(device, data));
+				}
 				buffer = null;
 				count = 0;
 			} // else

--- a/ble/src/main/java/no/nordicsemi/android/ble/data/PacketFilter.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/data/PacketFilter.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2018, Nordic Semiconductor
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this
+ * software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+ * USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package no.nordicsemi.android.ble.data;
+
+import androidx.annotation.Nullable;
+
+public interface PacketFilter {
+
+	/**
+	 * This method should return true if the packet matches the filter and should be processed
+	 * by the request.
+	 *
+	 * @param packet the complete, merged, packet received.
+	 * @return True, if packet should be processed, false if it should be ignored.
+	 */
+	boolean filter(@Nullable final byte[] packet);
+}


### PR DESCRIPTION
This PR fixes #312.

Before, the `filter(DataFilter)` method in `ValueChangedCallback` and `WaitForValueChanged` callbacks was only able to filter single packets before they were given to the merger.
The new `filterPacket(PacketFilter)` allows to filter the complete merged packets as well. Both data and packet filters can be set.