### PR TITLE
Progress indication as flow

### DIFF
--- a/ble-ktx/src/main/java/no/nordicsemi/android/ble/ktx/BluetoothGattServiceExt.kt
+++ b/ble-ktx/src/main/java/no/nordicsemi/android/ble/ktx/BluetoothGattServiceExt.kt
@@ -1,3 +1,5 @@
+@file:Suppress("unused")
+
 package no.nordicsemi.android.ble.ktx
 
 import android.bluetooth.BluetoothGattCharacteristic

--- a/ble-ktx/src/main/java/no/nordicsemi/android/ble/ktx/ProgressIndicaton.kt
+++ b/ble-ktx/src/main/java/no/nordicsemi/android/ble/ktx/ProgressIndicaton.kt
@@ -1,0 +1,136 @@
+@file:Suppress("unused")
+
+package no.nordicsemi.android.ble.ktx
+
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+import no.nordicsemi.android.ble.*
+import no.nordicsemi.android.ble.data.DataMerger
+import no.nordicsemi.android.ble.data.DataSplitter
+import no.nordicsemi.android.ble.data.DefaultMtuSplitter
+
+/**
+ * The upload or download progress indication.
+ *
+ * @property index The 0-based index of the packet. The packet will be app
+ */
+data class ProgressIndication(val index: Int, val data: ByteArray?) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as ProgressIndication
+
+        if (index != other.index) return false
+        if (data != null) {
+            if (other.data == null) return false
+            if (!data.contentEquals(other.data)) return false
+        } else if (other.data != null) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = index
+        result = 31 * result + (data?.contentHashCode() ?: 0)
+        return result
+    }
+}
+
+/**
+ * Adds a merger that will be used to merge multiple packets into a single Data.
+ * The merger may modify each packet if necessary.
+ *
+ * The returned flow will be notified each time a new packet is received.
+ *
+ * @return The flow with progress indications.
+ */
+fun ReadRequest.mergeWithProgressFlow(merger: DataMerger): Flow<ProgressIndication> = callbackFlow {
+    merge(merger)  { _, data, index -> trySend(ProgressIndication(index, data)) }
+    awaitClose {
+        merge(merger) // remove the progress listener, but keep the merger
+    }
+}
+
+/**
+ * Adds a merger that will be used to merge multiple packets into a single Data.
+ * The merger may modify each packet if necessary.
+ *
+ * The returned flow will be notified each time a new packet is received.
+ *
+ * @return The flow with progress indications.
+ */
+fun WaitForValueChangedRequest.mergeWithProgressFlow(merger: DataMerger): Flow<ProgressIndication> = callbackFlow {
+    merge(merger)  { _, data, index -> trySend(ProgressIndication(index, data)) }
+    awaitClose {
+        merge(merger) // remove the progress listener, but keep the merger
+    }
+}
+
+/**
+ * Adds a merger that will be used to merge multiple packets into a single Data.
+ * The merger may modify each packet if necessary.
+ *
+ * The returned flow will be notified each time a new packet is received.
+ *
+ * @return The flow with progress indications.
+ */
+fun ValueChangedCallback.mergeWithProgressFlow(merger: DataMerger): Flow<ProgressIndication> = callbackFlow {
+    merge(merger)  { _, data, index -> trySend(ProgressIndication(index, data)) }
+    awaitClose {
+        merge(merger) // remove the progress listener, but keep the merger
+    }
+}
+
+/**
+ * Adds a default MTU splitter that will be used to cut given data into at-most MTU-3
+ * bytes long packets.
+ *
+ * The returned flow will be notified each time a new packet is sent.
+ *
+ * @return The flow with progress indications.
+ */
+fun WriteRequest.splitWithProgressFlow(): Flow<ProgressIndication> = splitWithProgressFlow(DefaultMtuSplitter())
+
+/**
+ * Adds a splitter that will be used to cut given data into multiple packets.
+ * The splitter may modify each packet if necessary, i.e. add a flag indicating first packet,
+ * continuation or the last packet.
+ *
+ * The returned flow will be notified each time a new packet is sent.
+ *
+ * @return The flow with progress indications.
+ */
+fun WriteRequest.splitWithProgressFlow(splitter: DataSplitter): Flow<ProgressIndication> = callbackFlow {
+    split(splitter)  { _, data, index -> trySend(ProgressIndication(index, data)) }
+    awaitClose {
+        split(splitter) // remove the progress listener, but keep the merger
+    }
+}
+
+/**
+ * Adds a default MTU splitter that will be used to cut given data into at-most MTU-3
+ * bytes long packets.
+ *
+ * The returned flow will be notified each time a new packet is sent.
+ *
+ * @return The flow with progress indications.
+ */
+fun WaitForReadRequest.splitWithProgressFlow(): Flow<ProgressIndication> = splitWithProgressFlow(DefaultMtuSplitter())
+
+/**
+ * Adds a splitter that will be used to cut given data into multiple packets.
+ * The splitter may modify each packet if necessary, i.e. add a flag indicating first packet,
+ * continuation or the last packet.
+ *
+ * The returned flow will be notified each time a new packet is sent.
+ *
+ * @return The flow with progress indications.
+ */
+fun WaitForReadRequest.splitWithProgressFlow(splitter: DataSplitter): Flow<ProgressIndication> = callbackFlow {
+    split(splitter)  { _, data, index -> trySend(ProgressIndication(index, data)) }
+    awaitClose {
+        split(splitter) // remove the progress listener, but keep the merger
+    }
+}

--- a/ble-ktx/src/main/java/no/nordicsemi/android/ble/ktx/RequestSuspend.kt
+++ b/ble-ktx/src/main/java/no/nordicsemi/android/ble/ktx/RequestSuspend.kt
@@ -1,3 +1,5 @@
+@file:Suppress("unused")
+
 package no.nordicsemi.android.ble.ktx
 
 import android.bluetooth.BluetoothDevice

--- a/ble-ktx/src/main/java/no/nordicsemi/android/ble/ktx/ValueChangedCallbackExt.kt
+++ b/ble-ktx/src/main/java/no/nordicsemi/android/ble/ktx/ValueChangedCallbackExt.kt
@@ -1,3 +1,5 @@
+@file:Suppress("unused")
+
 package no.nordicsemi.android.ble.ktx
 
 import kotlinx.coroutines.ExperimentalCoroutinesApi

--- a/ble/src/main/java/no/nordicsemi/android/ble/BleManagerHandler.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/BleManagerHandler.java
@@ -2083,7 +2083,7 @@ abstract class BleManagerHandler extends RequestHandler {
 					if (matches) {
 						rr.notifyValueChanged(gatt.getDevice(), data);
 					}
-					if (!matches || !rr.isComplete()) {
+					if (!matches || rr.hasMore()) {
 						enqueueFirst(rr);
 					} else {
 						rr.notifySuccess(gatt.getDevice());
@@ -2197,7 +2197,7 @@ abstract class BleManagerHandler extends RequestHandler {
 				if (request instanceof ReadRequest) {
 					final ReadRequest request = (ReadRequest) BleManagerHandler.this.request;
 					request.notifyValueChanged(gatt.getDevice(), data);
-					if (!request.isComplete()) {
+					if (request.hasMore()) {
 						enqueueFirst(request);
 					} else {
 						request.notifySuccess(gatt.getDevice());

--- a/ble/src/main/java/no/nordicsemi/android/ble/ConditionalWaitRequest.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/ConditionalWaitRequest.java
@@ -44,7 +44,7 @@ public final class ConditionalWaitRequest<T> extends AwaitingRequest<T> implemen
 
 	@NonNull
 	@Override
-	public ConditionalWaitRequest<T> setHandler(@NonNull final Handler handler) {
+	public ConditionalWaitRequest<T> setHandler(@Nullable final Handler handler) {
 		super.setHandler(handler);
 		return this;
 	}

--- a/ble/src/main/java/no/nordicsemi/android/ble/ConnectRequest.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/ConnectRequest.java
@@ -31,6 +31,7 @@ import android.os.Handler;
 
 import androidx.annotation.IntRange;
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import no.nordicsemi.android.ble.annotation.PhyMask;
 import no.nordicsemi.android.ble.callback.AfterCallback;
 import no.nordicsemi.android.ble.callback.BeforeCallback;
@@ -74,7 +75,7 @@ public class ConnectRequest extends TimeoutableRequest {
 
 	@NonNull
 	@Override
-	public ConnectRequest setHandler(@NonNull final Handler handler) {
+	public ConnectRequest setHandler(@Nullable final Handler handler) {
 		super.setHandler(handler);
 		return this;
 	}

--- a/ble/src/main/java/no/nordicsemi/android/ble/ConnectionPriorityRequest.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/ConnectionPriorityRequest.java
@@ -28,6 +28,7 @@ import android.os.Handler;
 
 import androidx.annotation.IntRange;
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.annotation.RequiresApi;
 import no.nordicsemi.android.ble.annotation.ConnectionPriority;
 import no.nordicsemi.android.ble.callback.AfterCallback;
@@ -97,7 +98,7 @@ public final class ConnectionPriorityRequest extends SimpleValueRequest<Connecti
 
 	@NonNull
 	@Override
-	public ConnectionPriorityRequest setHandler(@NonNull final Handler handler) {
+	public ConnectionPriorityRequest setHandler(@Nullable final Handler handler) {
 		super.setHandler(handler);
 		return this;
 	}

--- a/ble/src/main/java/no/nordicsemi/android/ble/DisconnectRequest.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/DisconnectRequest.java
@@ -26,6 +26,7 @@ import android.os.Handler;
 
 import androidx.annotation.IntRange;
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import no.nordicsemi.android.ble.callback.AfterCallback;
 import no.nordicsemi.android.ble.callback.BeforeCallback;
 import no.nordicsemi.android.ble.callback.FailCallback;
@@ -47,7 +48,7 @@ public class DisconnectRequest extends TimeoutableRequest {
 
 	@NonNull
 	@Override
-	public DisconnectRequest setHandler(@NonNull final Handler handler) {
+	public DisconnectRequest setHandler(@Nullable final Handler handler) {
 		super.setHandler(handler);
 		return this;
 	}

--- a/ble/src/main/java/no/nordicsemi/android/ble/MtuRequest.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/MtuRequest.java
@@ -27,6 +27,7 @@ import android.os.Handler;
 
 import androidx.annotation.IntRange;
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import no.nordicsemi.android.ble.callback.AfterCallback;
 import no.nordicsemi.android.ble.callback.BeforeCallback;
 import no.nordicsemi.android.ble.callback.FailCallback;
@@ -55,7 +56,7 @@ public final class MtuRequest extends SimpleValueRequest<MtuCallback> implements
 
 	@NonNull
 	@Override
-	public MtuRequest setHandler(@NonNull final Handler handler) {
+	public MtuRequest setHandler(@Nullable final Handler handler) {
 		super.setHandler(handler);
 		return this;
 	}

--- a/ble/src/main/java/no/nordicsemi/android/ble/MtuRequest.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/MtuRequest.java
@@ -24,6 +24,7 @@ package no.nordicsemi.android.ble;
 
 import android.bluetooth.BluetoothDevice;
 import android.os.Handler;
+import android.util.Log;
 
 import androidx.annotation.IntRange;
 import androidx.annotation.NonNull;
@@ -106,8 +107,13 @@ public final class MtuRequest extends SimpleValueRequest<MtuCallback> implements
 	void notifyMtuChanged(@NonNull final BluetoothDevice device,
 						  @IntRange(from = 23, to = 517) final int mtu) {
 		handler.post(() -> {
-			if (valueCallback != null)
-				valueCallback.onMtuChanged(device, mtu);
+			if (valueCallback != null) {
+				try {
+					valueCallback.onMtuChanged(device, mtu);
+				} catch (final Throwable t) {
+					Log.e(TAG, "Exception in Value callback", t);
+				}
+			}
 		});
 	}
 

--- a/ble/src/main/java/no/nordicsemi/android/ble/PhyRequest.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/PhyRequest.java
@@ -26,6 +26,7 @@ import android.bluetooth.BluetoothDevice;
 import android.os.Handler;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import no.nordicsemi.android.ble.annotation.PhyMask;
 import no.nordicsemi.android.ble.annotation.PhyOption;
 import no.nordicsemi.android.ble.annotation.PhyValue;
@@ -106,7 +107,7 @@ public final class PhyRequest extends SimpleValueRequest<PhyCallback> implements
 
 	@NonNull
 	@Override
-	public PhyRequest setHandler(@NonNull final Handler handler) {
+	public PhyRequest setHandler(@Nullable final Handler handler) {
 		super.setHandler(handler);
 		return this;
 	}

--- a/ble/src/main/java/no/nordicsemi/android/ble/PhyRequest.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/PhyRequest.java
@@ -24,6 +24,7 @@ package no.nordicsemi.android.ble;
 
 import android.bluetooth.BluetoothDevice;
 import android.os.Handler;
+import android.util.Log;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -157,15 +158,24 @@ public final class PhyRequest extends SimpleValueRequest<PhyCallback> implements
 	void notifyPhyChanged(@NonNull final BluetoothDevice device,
 						  @PhyValue final int txPhy, @PhyValue final int rxPhy) {
 		handler.post(() -> {
-			if (valueCallback != null)
-				valueCallback.onPhyChanged(device, txPhy, rxPhy);
+			if (valueCallback != null) {
+				try {
+					valueCallback.onPhyChanged(device, txPhy, rxPhy);
+				} catch (final Throwable t) {
+					Log.e(TAG, "Exception in Value callback", t);
+				}
+			}
 		});
 	}
 
 	void notifyLegacyPhy(@NonNull final BluetoothDevice device) {
 		handler.post(() -> {
 			if (valueCallback != null)
-				valueCallback.onPhyChanged(device, PhyCallback.PHY_LE_1M, PhyCallback.PHY_LE_1M);
+				try {
+					valueCallback.onPhyChanged(device, PhyCallback.PHY_LE_1M, PhyCallback.PHY_LE_1M);
+				} catch (final Throwable t) {
+					Log.e(TAG, "Exception in Value callback", t);
+				}
 		});
 	}
 

--- a/ble/src/main/java/no/nordicsemi/android/ble/ReadRequest.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/ReadRequest.java
@@ -80,7 +80,7 @@ public final class ReadRequest extends SimpleValueRequest<DataReceivedCallback> 
 
 	@NonNull
 	@Override
-	public ReadRequest setHandler(@NonNull final Handler handler) {
+	public ReadRequest setHandler(@Nullable final Handler handler) {
 		super.setHandler(handler);
 		return this;
 	}

--- a/ble/src/main/java/no/nordicsemi/android/ble/ReadRequest.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/ReadRequest.java
@@ -313,7 +313,7 @@ public final class ReadRequest extends SimpleValueRequest<DataReceivedCallback> 
 	}
 
 	@SuppressWarnings("BooleanMethodIsAlwaysInverted")
-	boolean isComplete() {
-		return complete;
+	boolean hasMore() {
+		return !complete;
 	}
 }

--- a/ble/src/main/java/no/nordicsemi/android/ble/ReadRssiRequest.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/ReadRssiRequest.java
@@ -24,6 +24,7 @@ package no.nordicsemi.android.ble;
 
 import android.bluetooth.BluetoothDevice;
 import android.os.Handler;
+import android.util.Log;
 
 import androidx.annotation.IntRange;
 import androidx.annotation.NonNull;
@@ -100,8 +101,13 @@ public final class ReadRssiRequest extends SimpleValueRequest<RssiCallback> impl
 	void notifyRssiRead(@NonNull final BluetoothDevice device,
 						@IntRange(from = -128, to = 20) final int rssi) {
 		handler.post(() -> {
-			if (valueCallback != null)
-				valueCallback.onRssiRead(device, rssi);
+			if (valueCallback != null) {
+				try {
+					valueCallback.onRssiRead(device, rssi);
+				} catch (final Throwable t) {
+					Log.e(TAG, "Exception in Value callback", t);
+				}
+			}
 		});
 	}
 }

--- a/ble/src/main/java/no/nordicsemi/android/ble/ReadRssiRequest.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/ReadRssiRequest.java
@@ -27,6 +27,7 @@ import android.os.Handler;
 
 import androidx.annotation.IntRange;
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import no.nordicsemi.android.ble.callback.AfterCallback;
 import no.nordicsemi.android.ble.callback.BeforeCallback;
 import no.nordicsemi.android.ble.callback.FailCallback;
@@ -49,7 +50,7 @@ public final class ReadRssiRequest extends SimpleValueRequest<RssiCallback> impl
 
 	@NonNull
 	@Override
-	public ReadRssiRequest setHandler(@NonNull final Handler handler) {
+	public ReadRssiRequest setHandler(@Nullable final Handler handler) {
 		super.setHandler(handler);
 		return this;
 	}

--- a/ble/src/main/java/no/nordicsemi/android/ble/ReliableWriteRequest.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/ReliableWriteRequest.java
@@ -25,6 +25,7 @@ package no.nordicsemi.android.ble;
 import android.os.Handler;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import no.nordicsemi.android.ble.callback.AfterCallback;
 import no.nordicsemi.android.ble.callback.BeforeCallback;
 import no.nordicsemi.android.ble.callback.FailCallback;
@@ -46,7 +47,7 @@ public final class ReliableWriteRequest extends RequestQueue {
 
 	@NonNull
 	@Override
-	public ReliableWriteRequest setHandler(@NonNull final Handler handler) {
+	public ReliableWriteRequest setHandler(@Nullable final Handler handler) {
 		super.setHandler(handler);
 		return this;
 	}

--- a/ble/src/main/java/no/nordicsemi/android/ble/Request.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/Request.java
@@ -139,8 +139,8 @@ public abstract class Request {
 
 	/**
 	 * Sets the {@link BleManager} instance.
-	 *  @param requestHandler the requestHandler in which the request will be executed.
 	 *
+	 *  @param requestHandler the requestHandler in which the request will be executed.
 	 */
 	@NonNull
 	Request setRequestHandler(@NonNull final RequestHandler requestHandler) {
@@ -155,25 +155,31 @@ public abstract class Request {
 	 * Sets the handler that will be used to invoke callbacks. By default, the handler set in
 	 * {@link BleManager} will be used.
 	 *
+	 * If set to null, the callbacks will be invoked immediately on the BLE looper.
+	 *
 	 * @param handler The handler to invoke callbacks for this request.
 	 * @return The request.
+	 * @apiNote Since version 2.4.0 this method accepts null as parameter.
 	 */
 	@NonNull
-	public Request setHandler(@NonNull final Handler handler) {
+	public Request setHandler(@Nullable final Handler handler) {
 		this.handler = new CallbackHandler() {
 			@Override
 			public void post(@NonNull final Runnable r) {
-				handler.post(r);
+				if (handler != null) handler.post(r);
+				else r.run();
 			}
 
 			@Override
 			public void postDelayed(@NonNull final Runnable r, final long delayMillis) {
-				handler.postDelayed(r, delayMillis);
+				if (handler != null) handler.postDelayed(r, delayMillis);
+				else requestHandler.postDelayed(r, delayMillis);
 			}
 
 			@Override
 			public void removeCallbacks(@NonNull final Runnable r) {
-				handler.removeCallbacks(r);
+				if (handler != null) handler.removeCallbacks(r);
+				else requestHandler.removeCallbacks(r);
 			}
 		};
 		return this;

--- a/ble/src/main/java/no/nordicsemi/android/ble/Request.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/Request.java
@@ -30,6 +30,7 @@ import android.bluetooth.BluetoothGattDescriptor;
 import android.os.ConditionVariable;
 import android.os.Handler;
 import android.os.Looper;
+import android.util.Log;
 
 import androidx.annotation.IntRange;
 import androidx.annotation.NonNull;
@@ -54,6 +55,7 @@ import no.nordicsemi.android.ble.data.Data;
  */
 @SuppressWarnings({"unused", "WeakerAccess", "deprecation", "DeprecatedIsStillUsed"})
 public abstract class Request {
+	protected static final String TAG = Request.class.getSimpleName();
 
 	enum Type {
 		SET,
@@ -1214,8 +1216,13 @@ public abstract class Request {
 			if (internalBeforeCallback != null)
 				internalBeforeCallback.onRequestStarted(device);
 			handler.post(() -> {
-				if (beforeCallback != null)
-					beforeCallback.onRequestStarted(device);
+				if (beforeCallback != null) {
+					try {
+						beforeCallback.onRequestStarted(device);
+					} catch (final Throwable t) {
+						Log.e(TAG, "Exception in Before callback", t);
+					}
+				}
 			});
 		}
 	}
@@ -1227,10 +1234,20 @@ public abstract class Request {
 			if (internalSuccessCallback != null)
 				internalSuccessCallback.onRequestCompleted(device);
 			handler.post(() -> {
-				if (successCallback != null)
-					successCallback.onRequestCompleted(device);
-				if (afterCallback != null)
-					afterCallback.onRequestFinished(device);
+				if (successCallback != null) {
+					try {
+						successCallback.onRequestCompleted(device);
+					} catch (final Throwable t) {
+						Log.e(TAG, "Exception in Success callback", t);
+					}
+				}
+				if (afterCallback != null) {
+					try {
+						afterCallback.onRequestFinished(device);
+					} catch (final Throwable t) {
+						Log.e(TAG, "Exception in After callback", t);
+					}
+				}
 			});
 			return true;
 		}
@@ -1244,10 +1261,20 @@ public abstract class Request {
 			if (internalFailCallback != null)
 				internalFailCallback.onRequestFailed(device, status);
 			handler.post(() -> {
-				if (failCallback != null)
-					failCallback.onRequestFailed(device, status);
-				if (afterCallback != null)
-					afterCallback.onRequestFinished(device);
+				if (failCallback != null) {
+					try {
+						failCallback.onRequestFailed(device, status);
+					} catch (final Throwable t) {
+						Log.e(TAG, "Exception in Fail callback", t);
+					}
+				}
+				if (afterCallback != null) {
+					try {
+						afterCallback.onRequestFinished(device);
+					} catch (final Throwable t) {
+						Log.e(TAG, "Exception in After callback", t);
+					}
+				}
 			});
 		}
 	}
@@ -1257,8 +1284,13 @@ public abstract class Request {
 			finished = true;
 
 			handler.post(() -> {
-				if (invalidRequestCallback != null)
-					invalidRequestCallback.onInvalidRequest();
+				if (invalidRequestCallback != null) {
+					try {
+						invalidRequestCallback.onInvalidRequest();
+					} catch (final Throwable t) {
+						Log.e(TAG, "Exception in Invalid Request callback", t);
+					}
+				}
 			});
 		}
 	}

--- a/ble/src/main/java/no/nordicsemi/android/ble/RequestQueue.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/RequestQueue.java
@@ -64,7 +64,7 @@ public class RequestQueue extends Request {
 
 	@NonNull
 	@Override
-	public RequestQueue setHandler(@NonNull final Handler handler) {
+	public RequestQueue setHandler(@Nullable final Handler handler) {
 		super.setHandler(handler);
 		return this;
 	}

--- a/ble/src/main/java/no/nordicsemi/android/ble/SetValueRequest.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/SetValueRequest.java
@@ -41,7 +41,7 @@ public final class SetValueRequest extends SimpleRequest {
 
 	@NonNull
 	@Override
-	public SetValueRequest setHandler(@NonNull final Handler handler) {
+	public SetValueRequest setHandler(@Nullable final Handler handler) {
 		super.setHandler(handler);
 		return this;
 	}

--- a/ble/src/main/java/no/nordicsemi/android/ble/SleepRequest.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/SleepRequest.java
@@ -26,6 +26,7 @@ import android.os.Handler;
 
 import androidx.annotation.IntRange;
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import no.nordicsemi.android.ble.callback.AfterCallback;
 import no.nordicsemi.android.ble.callback.BeforeCallback;
 import no.nordicsemi.android.ble.callback.FailCallback;
@@ -49,7 +50,7 @@ public final class SleepRequest extends SimpleRequest implements Operation {
 
 	@NonNull
 	@Override
-	public SleepRequest setHandler(@NonNull final Handler handler) {
+	public SleepRequest setHandler(@Nullable final Handler handler) {
 		super.setHandler(handler);
 		return this;
 	}

--- a/ble/src/main/java/no/nordicsemi/android/ble/TimeoutableRequest.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/TimeoutableRequest.java
@@ -41,7 +41,7 @@ public abstract class TimeoutableRequest extends Request {
 
 	@NonNull
 	@Override
-	public TimeoutableRequest setHandler(@NonNull final Handler handler) {
+	public TimeoutableRequest setHandler(@Nullable final Handler handler) {
 		super.setHandler(handler);
 		return this;
 	}

--- a/ble/src/main/java/no/nordicsemi/android/ble/ValueChangedCallback.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/ValueChangedCallback.java
@@ -51,21 +51,24 @@ public class ValueChangedCallback {
 	}
 
 	@NonNull
-	public ValueChangedCallback setHandler(@NonNull final Handler handler) {
+	public ValueChangedCallback setHandler(@Nullable final Handler handler) {
 		this.handler = new CallbackHandler() {
 			@Override
 			public void post(@NonNull final Runnable r) {
-				handler.post(r);
+				if (handler != null)
+					handler.post(r);
+				else
+					r.run();
 			}
 
 			@Override
 			public void postDelayed(@NonNull final Runnable r, final long delayMillis) {
-				handler.postDelayed(r, delayMillis);
+				// not used
 			}
 
 			@Override
 			public void removeCallbacks(@NonNull final Runnable r) {
-				handler.removeCallbacks(r);
+				// not used
 			}
 		};
 		return this;

--- a/ble/src/main/java/no/nordicsemi/android/ble/WaitForReadRequest.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/WaitForReadRequest.java
@@ -74,7 +74,7 @@ public final class WaitForReadRequest extends AwaitingRequest<DataSentCallback> 
 
 	@NonNull
 	@Override
-	public WaitForReadRequest setHandler(@NonNull final Handler handler) {
+	public WaitForReadRequest setHandler(@Nullable final Handler handler) {
 		super.setHandler(handler);
 		return this;
 	}

--- a/ble/src/main/java/no/nordicsemi/android/ble/WaitForReadRequest.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/WaitForReadRequest.java
@@ -4,6 +4,7 @@ import android.bluetooth.BluetoothDevice;
 import android.bluetooth.BluetoothGattCharacteristic;
 import android.bluetooth.BluetoothGattDescriptor;
 import android.os.Handler;
+import android.util.Log;
 
 import androidx.annotation.IntRange;
 import androidx.annotation.NonNull;
@@ -234,8 +235,13 @@ public final class WaitForReadRequest extends AwaitingRequest<DataSentCallback> 
 	 */
 	void notifyPacketRead(@NonNull final BluetoothDevice device, @Nullable final byte[] data) {
 		handler.post(() -> {
-			if (progressCallback != null)
-				progressCallback.onPacketSent(device, data, count);
+			if (progressCallback != null) {
+				try {
+					progressCallback.onPacketSent(device, data, count);
+				} catch (final Throwable t) {
+					Log.e(TAG, "Exception in Progress callback", t);
+				}
+			}
 		});
 		count++;
 	}
@@ -243,8 +249,13 @@ public final class WaitForReadRequest extends AwaitingRequest<DataSentCallback> 
 	@Override
 	boolean notifySuccess(@NonNull final BluetoothDevice device) {
 		handler.post(() -> {
-			if (valueCallback != null)
-				valueCallback.onDataSent(device, new Data(data));
+			if (valueCallback != null) {
+				try {
+					valueCallback.onDataSent(device, new Data(data));
+				} catch (final Throwable t) {
+					Log.e(TAG, "Exception in Value callback", t);
+				}
+			}
 		});
 		return super.notifySuccess(device);
 	}

--- a/ble/src/main/java/no/nordicsemi/android/ble/WaitForValueChangedRequest.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/WaitForValueChangedRequest.java
@@ -80,7 +80,7 @@ public final class WaitForValueChangedRequest extends AwaitingRequest<DataReceiv
 
 	@NonNull
 	@Override
-	public WaitForValueChangedRequest setHandler(@NonNull final Handler handler) {
+	public WaitForValueChangedRequest setHandler(@Nullable final Handler handler) {
 		super.setHandler(handler);
 		return this;
 	}

--- a/ble/src/main/java/no/nordicsemi/android/ble/WriteRequest.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/WriteRequest.java
@@ -27,6 +27,7 @@ import android.bluetooth.BluetoothGatt;
 import android.bluetooth.BluetoothGattCharacteristic;
 import android.bluetooth.BluetoothGattDescriptor;
 import android.os.Handler;
+import android.util.Log;
 
 import java.util.Arrays;
 
@@ -269,14 +270,24 @@ public final class WriteRequest extends SimpleValueRequest<DataSentCallback> imp
 	 */
 	boolean notifyPacketSent(@NonNull final BluetoothDevice device, @Nullable final byte[] data) {
 		handler.post(() -> {
-			if (progressCallback != null)
-				progressCallback.onPacketSent(device, data, count);
+			if (progressCallback != null) {
+				try {
+					progressCallback.onPacketSent(device, data, count);
+				} catch (final Throwable t) {
+					Log.e(TAG, "Exception in Progress callback", t);
+				}
+			}
 		});
 		count++;
 		if (complete) {
 			handler.post(() -> {
-				if (valueCallback != null)
-					valueCallback.onDataSent(device, new Data(WriteRequest.this.data));
+				if (valueCallback != null) {
+					try {
+						valueCallback.onDataSent(device, new Data(WriteRequest.this.data));
+					} catch (final Throwable t) {
+						Log.e(TAG, "Exception in Value callback", t);
+					}
+				}
 			});
 		}
 		return Arrays.equals(data, currentChunk);

--- a/ble/src/main/java/no/nordicsemi/android/ble/WriteRequest.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/WriteRequest.java
@@ -105,7 +105,7 @@ public final class WriteRequest extends SimpleValueRequest<DataSentCallback> imp
 
 	@NonNull
 	@Override
-	public WriteRequest setHandler(@NonNull final Handler handler) {
+	public WriteRequest setHandler(@Nullable final Handler handler) {
 		super.setHandler(handler);
 		return this;
 	}


### PR DESCRIPTION
This PR fixes #315.

## Changes
- `mergeWithProgressFlow` methods added to `ReadRequest`, `WaitForValueChangedRequest`, `ValueChangedCallback`.
- `splitWithProgressFlow` methods added to `WriteRequest`, `WaitForReadRequest`.
- `setHandler(...)` method in `Request` (and any extending class) allows *null* as parameter. This allows to bypass the `Handler` when calling user callbacks.
- User callbacks are not wrapped in `try-catch` blocks to catch exceptions.

Work in Progress.