### PR TITLE
Allow sending empty packets

### DIFF
--- a/ble-common/build.gradle
+++ b/ble-common/build.gradle
@@ -1,6 +1,8 @@
 apply plugin: 'com.android.library'
 
 android {
+    namespace 'no.nordicsemi.android.ble.common'
+
     compileSdkVersion 30
 
     defaultConfig {

--- a/ble-common/src/main/AndroidManifest.xml
+++ b/ble-common/src/main/AndroidManifest.xml
@@ -1,2 +1,2 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="no.nordicsemi.android.ble.common"/>
+<manifest />

--- a/ble-ktx/build.gradle
+++ b/ble-ktx/build.gradle
@@ -4,6 +4,8 @@ plugins {
 }
 
 android {
+    namespace 'no.nordicsemi.android.ble.ktx'
+
     compileSdkVersion 30
 
     defaultConfig {

--- a/ble-ktx/src/main/AndroidManifest.xml
+++ b/ble-ktx/src/main/AndroidManifest.xml
@@ -1,2 +1,2 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="no.nordicsemi.android.ble.ktx" />
+<manifest />

--- a/ble-livedata/build.gradle
+++ b/ble-livedata/build.gradle
@@ -3,6 +3,8 @@ plugins {
 }
 
 android {
+    namespace 'no.nordicsemi.android.ble.livedata'
+
     compileSdkVersion 30
 
     defaultConfig {

--- a/ble-livedata/src/main/AndroidManifest.xml
+++ b/ble-livedata/src/main/AndroidManifest.xml
@@ -1,2 +1,2 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="no.nordicsemi.android.ble.livedata" />
+<manifest />

--- a/ble/build.gradle
+++ b/ble/build.gradle
@@ -1,6 +1,8 @@
 apply plugin: 'com.android.library'
 
 android {
+    namespace 'no.nordicsemi.android.ble'
+
     compileSdkVersion 30
 
     defaultConfig {

--- a/ble/src/main/AndroidManifest.xml
+++ b/ble/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-	package="no.nordicsemi.android.ble">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
 	<uses-permission android:name="android.permission.BLUETOOTH" android:maxSdkVersion="30" />
 

--- a/ble/src/main/java/no/nordicsemi/android/ble/WaitForReadRequest.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/WaitForReadRequest.java
@@ -198,10 +198,11 @@ public final class WaitForReadRequest extends AwaitingRequest<DataSentCallback> 
 	 * @param mtu the current MTU.
 	 * @return The next bytes to be sent.
 	 */
+	@NonNull
 	byte[] getData(@IntRange(from = 23, to = 517) final int mtu) {
 		if (dataSplitter == null || data == null) {
 			complete = true;
-			return data;
+			return data != null ? data : new byte[] {};
 		}
 
 		// Read [procedure requires 3 bytes for handler and op code.
@@ -220,7 +221,7 @@ public final class WaitForReadRequest extends AwaitingRequest<DataSentCallback> 
 		if (nextChunk == null) {
 			complete = true;
 		}
-		return chunk;
+		return chunk != null ? chunk : new byte[] {};
 	}
 
 	/**

--- a/ble/src/main/java/no/nordicsemi/android/ble/WriteRequest.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/WriteRequest.java
@@ -232,10 +232,12 @@ public final class WriteRequest extends SimpleValueRequest<DataSentCallback> imp
 	 * @param mtu the current MTU.
 	 * @return The next bytes to be sent.
 	 */
+	@NonNull
 	byte[] getData(@IntRange(from = 23, to = 517) final int mtu) {
 		if (dataSplitter == null || data == null) {
 			complete = true;
-			return currentChunk = data;
+			currentChunk = data;
+			return data != null ? data : new byte[] {};
 		}
 
 		// Write Request and Write Command require 3 bytes for handler and op code.
@@ -256,7 +258,8 @@ public final class WriteRequest extends SimpleValueRequest<DataSentCallback> imp
 		if (nextChunk == null) {
 			complete = true;
 		}
-		return currentChunk = chunk;
+		currentChunk = chunk;
+		return chunk != null ? chunk : new byte[] {};
 	}
 
 	/**

--- a/ble/src/main/java/no/nordicsemi/android/ble/data/DataSplitter.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/data/DataSplitter.java
@@ -42,5 +42,6 @@ public interface DataSplitter {
 	 */
 	@Nullable
 	byte[] chunk(@NonNull final byte[] message,
-				 @IntRange(from = 0) final int index, @IntRange(from = 20) final int maxLength);
+				 @IntRange(from = 0) final int index,
+				 @IntRange(from = 20) final int maxLength);
 }

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
         maven { url "https://plugins.gradle.org/m2/" }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.1.2'
+        classpath 'com.android.tools.build:gradle:7.1.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "io.github.gradle-nexus:publish-plugin:$gradle_nexus_publish_plugin"
     }


### PR DESCRIPTION
## Changes
- Increase gradle version.
- Move package name to gradle files.
- Enable sending empty string using WriteRequest.

On Android 12 (and perhaps before as well), `gatt.writeCharacteristic(...)` returns *false* if the characteristic value is *null*. This effectively disallow sending empty packets. This PR changes *null* to an empty array to workaround it.