### PR TITLE
Feature: Connection parameters listener

### DIFF
--- a/ble/src/main/java/no/nordicsemi/android/ble/BleManager.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/BleManager.java
@@ -53,6 +53,7 @@ import no.nordicsemi.android.ble.annotation.PairingVariant;
 import no.nordicsemi.android.ble.annotation.PhyMask;
 import no.nordicsemi.android.ble.annotation.PhyOption;
 import no.nordicsemi.android.ble.annotation.WriteType;
+import no.nordicsemi.android.ble.callback.ConnectionParametersUpdatedCallback;
 import no.nordicsemi.android.ble.observer.BondingObserver;
 import no.nordicsemi.android.ble.observer.ConnectionObserver;
 import no.nordicsemi.android.ble.callback.ConnectionPriorityCallback;
@@ -1882,6 +1883,16 @@ public abstract class BleManager implements ILogger {
 			@ConnectionPriority final int priority) {
 		return Request.newConnectionPriorityRequest(priority)
 				.setRequestHandler(requestHandler);
+	}
+
+	/**
+	 * Sets connection priority listener.
+	 *
+	 * @param callback the callback, that will receive all connection parameters updates.
+	 */
+	@RequiresApi(api = Build.VERSION_CODES.O)
+	protected void setConnectionParametersListener(@Nullable final ConnectionParametersUpdatedCallback callback) {
+		requestHandler.setConnectionParametersListener(callback);
 	}
 
 	/**

--- a/ble/src/main/java/no/nordicsemi/android/ble/ConnectionPriorityRequest.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/ConnectionPriorityRequest.java
@@ -33,6 +33,7 @@ import androidx.annotation.RequiresApi;
 import no.nordicsemi.android.ble.annotation.ConnectionPriority;
 import no.nordicsemi.android.ble.callback.AfterCallback;
 import no.nordicsemi.android.ble.callback.BeforeCallback;
+import no.nordicsemi.android.ble.callback.ConnectionParametersUpdatedCallback;
 import no.nordicsemi.android.ble.callback.ConnectionPriorityCallback;
 import no.nordicsemi.android.ble.callback.FailCallback;
 import no.nordicsemi.android.ble.callback.InvalidRequestCallback;
@@ -42,7 +43,7 @@ import no.nordicsemi.android.ble.exception.DeviceDisconnectedException;
 import no.nordicsemi.android.ble.exception.InvalidRequestException;
 import no.nordicsemi.android.ble.exception.RequestFailedException;
 
-public final class ConnectionPriorityRequest extends SimpleValueRequest<ConnectionPriorityCallback>
+public final class ConnectionPriorityRequest extends SimpleValueRequest<ConnectionParametersUpdatedCallback>
 		implements Operation {
 
 	/**
@@ -138,10 +139,28 @@ public final class ConnectionPriorityRequest extends SimpleValueRequest<Connecti
 		return this;
 	}
 
+	/**
+	 * Sets the value callback. When the request is invoked synchronously, this callback will
+	 * be ignored and the received value will be returned by the <code>await(...)</code> method;
+	 *
+	 * @param callback the callback.
+	 * @return The request.
+	 * @deprecated Use {@link #with(ConnectionParametersUpdatedCallback)} instead.
+	 */
+	@SuppressWarnings("deprecation")
+	@RequiresApi(value = Build.VERSION_CODES.O)
+	@NonNull
+	@Deprecated
+	public ConnectionPriorityRequest with(@NonNull final ConnectionPriorityCallback callback) {
+		// The BluetoothGattCallback#onConnectionUpdated callback was introduced in Android Oreo.
+		super.with(callback);
+		return this;
+	}
+
 	@RequiresApi(value = Build.VERSION_CODES.O)
 	@Override
 	@NonNull
-	public ConnectionPriorityRequest with(@NonNull final ConnectionPriorityCallback callback) {
+	public ConnectionPriorityRequest with(@NonNull final ConnectionParametersUpdatedCallback callback) {
 		// The BluetoothGattCallback#onConnectionUpdated callback was introduced in Android Oreo.
 		super.with(callback);
 		return this;
@@ -150,7 +169,7 @@ public final class ConnectionPriorityRequest extends SimpleValueRequest<Connecti
 	@RequiresApi(value = Build.VERSION_CODES.O)
 	@NonNull
 	@Override
-	public <E extends ConnectionPriorityCallback> E await(@NonNull final Class<E> responseClass)
+	public <E extends ConnectionParametersUpdatedCallback> E await(@NonNull final Class<E> responseClass)
 			throws RequestFailedException, DeviceDisconnectedException, BluetoothDisabledException,
 			InvalidRequestException {
 		// The BluetoothGattCallback#onConnectionUpdated callback was introduced in Android Oreo.
@@ -160,7 +179,7 @@ public final class ConnectionPriorityRequest extends SimpleValueRequest<Connecti
 	@RequiresApi(value = Build.VERSION_CODES.O)
 	@NonNull
 	@Override
-	public <E extends ConnectionPriorityCallback> E await(@NonNull final E response)
+	public <E extends ConnectionParametersUpdatedCallback> E await(@NonNull final E response)
 			throws RequestFailedException, DeviceDisconnectedException, BluetoothDisabledException,
 			InvalidRequestException {
 		// The BluetoothGattCallback#onConnectionUpdated callback was introduced in Android Oreo.

--- a/ble/src/main/java/no/nordicsemi/android/ble/callback/ConnectionParametersUpdatedCallback.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/callback/ConnectionParametersUpdatedCallback.java
@@ -22,6 +22,11 @@
 
 package no.nordicsemi.android.ble.callback;
 
+import android.bluetooth.BluetoothDevice;
+
+import androidx.annotation.IntRange;
+import androidx.annotation.NonNull;
+
 /**
  * The connection parameters for a Bluetooth LE connection is a set of parameters that determine
  * when and how the Central and a Peripheral in a link transmits data.
@@ -40,11 +45,23 @@ package no.nordicsemi.android.ble.callback;
  * explicit calling of this method, the application was not aware of it.
  * Android Oreo added a hidden callback to {@link android.bluetooth.BluetoothGattCallback}
  * notifying about connection parameters change. Those values will be reported with this callback.
- *
- * @deprecated Use {@link ConnectionParametersUpdatedCallback} instead.
  */
-@Deprecated
 @FunctionalInterface
-public interface ConnectionPriorityCallback extends ConnectionParametersUpdatedCallback {
-	// No extra methods.
+public interface ConnectionParametersUpdatedCallback {
+
+	/**
+	 * Callback indicating the connection parameters were updated. Works on Android 8.0 Oreo or newer.
+	 *
+	 * @param device   the target device.
+	 * @param interval Connection interval used on this connection, 1.25ms unit. Valid range is from
+	 *                 6 (7.5ms) to 3200 (4000ms).
+	 * @param latency  Slave latency for the connection in number of connection events. Valid range
+	 *                 is from 0 to 499.
+	 * @param timeout  Supervision timeout for this connection, in 10ms unit. Valid range is from 10
+	 *                 (100 ms = 0.1s) to 3200 (32s).
+	 */
+	void onConnectionUpdated(@NonNull final BluetoothDevice device,
+							 @IntRange(from = 6, to = 3200) final int interval,
+							 @IntRange(from = 0, to = 499) final int latency,
+							 @IntRange(from = 10, to = 3200) final int timeout);
 }

--- a/ble/src/main/java/no/nordicsemi/android/ble/response/ConnectionPriorityResponse.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/response/ConnectionPriorityResponse.java
@@ -29,15 +29,15 @@ import android.os.Parcelable;
 import androidx.annotation.IntRange;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import no.nordicsemi.android.ble.callback.ConnectionPriorityCallback;
+import no.nordicsemi.android.ble.callback.ConnectionParametersUpdatedCallback;
 
 /**
  * The synchronous response type for connection priority requests.
  *
- * @see ConnectionPriorityCallback
+ * @see ConnectionParametersUpdatedCallback
  */
 @SuppressWarnings({"unused", "WeakerAccess"})
-public class ConnectionPriorityResponse implements ConnectionPriorityCallback, Parcelable {
+public class ConnectionPriorityResponse implements ConnectionParametersUpdatedCallback, Parcelable {
 	private BluetoothDevice device;
 
 	@IntRange(from = 6, to = 3200)


### PR DESCRIPTION
This PR introduces a way to set connection parameters listener. This works only for Android 8+.

### Deprecation
The `ConnectionPriorityCallback` interface has been deprecated in favor of `ConnectionParametersUpdatedCallback`.
For migration, just change the interface name. Everything else should be the same.