### PR TITLE
Keep on connection updated method

### DIFF
--- a/ble/src/main/java/no/nordicsemi/android/ble/BleManagerHandler.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/BleManagerHandler.java
@@ -2458,6 +2458,7 @@ abstract class BleManagerHandler extends RequestHandler {
 		 */
 		@RequiresApi(api = Build.VERSION_CODES.O)
 		// @Override
+		@Keep
 		public void onConnectionUpdated(@NonNull final BluetoothGatt gatt,
 										@IntRange(from = 6, to = 3200) final int interval,
 										@IntRange(from = 0, to = 499) final int latency,

--- a/ble/src/main/java/no/nordicsemi/android/ble/BleManagerHandler.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/BleManagerHandler.java
@@ -1785,7 +1785,7 @@ abstract class BleManagerHandler extends RequestHandler {
 	 *                 Valid range is from 0 to 499.
 	 * @param timeout  Supervision timeout for this connection, in 10ms unit.
 	 *                 Valid range is from 10 (0.1s) to 3200 (32s).
-	 * @deprecated Use {@link ConnectionPriorityRequest#with(ConnectionPriorityCallback)} instead.
+	 * @deprecated Use {@link ConnectionPriorityRequest#with(ConnectionParametersUpdatedCallback)} instead.
 	 */
 	@Deprecated
 	@TargetApi(Build.VERSION_CODES.O)


### PR DESCRIPTION
The following method:
https://github.com/NordicSemiconductor/Android-BLE-Library/blob/b01984e0cff7a1a52559e6f0e1d0163b038072cd/ble/src/main/java/no/nordicsemi/android/ble/BleManagerHandler.java#L2461-L2465
method was being removed by Proguard and R8 as it seems not being used. In fact, it overrides a hidden method in `BluetoothGattCallback`. Marking it as `@Keep` will solve the issue.