### PR TITLE
Cancellation support

### DIFF
--- a/ble-ktx/src/main/java/no/nordicsemi/android/ble/ktx/BleManagerExt.kt
+++ b/ble-ktx/src/main/java/no/nordicsemi/android/ble/ktx/BleManagerExt.kt
@@ -4,8 +4,6 @@ package no.nordicsemi.android.ble.ktx
 
 import android.annotation.SuppressLint
 import android.bluetooth.BluetoothDevice
-import kotlinx.coroutines.InternalCoroutinesApi
-import kotlinx.coroutines.flow.FlowCollector
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import no.nordicsemi.android.ble.BleManager

--- a/ble-ktx/src/main/java/no/nordicsemi/android/ble/ktx/RequestSuspend.kt
+++ b/ble-ktx/src/main/java/no/nordicsemi/android/ble/ktx/RequestSuspend.kt
@@ -3,7 +3,6 @@
 package no.nordicsemi.android.ble.ktx
 
 import android.bluetooth.BluetoothDevice
-import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.suspendCancellableCoroutine
 import no.nordicsemi.android.ble.*
 import no.nordicsemi.android.ble.callback.FailCallback
@@ -364,7 +363,7 @@ private suspend fun Request.suspendCancellable(): Unit = suspendCancellableCorou
 		.invalid { continuation.resumeWithException(InvalidRequestException(this)) }
 		.fail { _, status ->
 			val exception = when (status) {
-				FailCallback.REASON_CANCELLED -> CancellationException()
+				FailCallback.REASON_CANCELLED -> return@fail
 				FailCallback.REASON_BLUETOOTH_DISABLED -> BluetoothDisabledException()
 				FailCallback.REASON_DEVICE_DISCONNECTED -> DeviceDisconnectedException()
 				else -> RequestFailedException(this, status)

--- a/ble-ktx/src/main/java/no/nordicsemi/android/ble/ktx/RequestSuspend.kt
+++ b/ble-ktx/src/main/java/no/nordicsemi/android/ble/ktx/RequestSuspend.kt
@@ -13,6 +13,7 @@ import no.nordicsemi.android.ble.response.ReadResponse
 import no.nordicsemi.android.ble.response.WriteResponse
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
+import kotlin.coroutines.suspendCoroutine
 
 /**
  * Suspends the coroutine until the request is completed.
@@ -24,7 +25,19 @@ import kotlin.coroutines.resumeWithException
 	RequestFailedException::class,
 	InvalidRequestException::class
 )
-suspend fun Request.suspend() = suspendCancellable()
+suspend fun SimpleRequest.suspend() = suspendNonCancellable()
+
+/**
+ * Suspends the coroutine until the request is completed.
+ * @since 2.3.0
+ */
+@Throws(
+	BluetoothDisabledException::class,
+	DeviceDisconnectedException::class,
+	RequestFailedException::class,
+	InvalidRequestException::class
+)
+suspend fun TimeoutableRequest.suspend() = suspendCancellable()
 
 /**
  * Suspends the coroutine until the data have been written.
@@ -41,7 +54,7 @@ suspend fun WriteRequest.suspend(): Data {
 	var result: Data? = null
 	this
 		.with { _, data -> result = data }
-		.suspendCancellable()
+		.suspendNonCancellable()
 	return result!!
 }
 
@@ -93,7 +106,7 @@ suspend fun ReadRequest.suspend(): Data {
 	var result: Data? = null
 	this
 		.with { _, data -> result = data }
-		.suspendCancellable()
+		.suspendNonCancellable()
 	return result!!
 }
 
@@ -165,7 +178,7 @@ suspend fun ReadRssiRequest.suspend(): Int {
 	var result: Int? = null
 	this
 		.with { _, rssi -> result = rssi }
-		.suspendCancellable()
+		.suspendNonCancellable()
 	return result!!
 }
 
@@ -184,7 +197,7 @@ suspend fun MtuRequest.suspend(): Int {
 	var result: Int? = null
 	this
 		.with { _, mtu -> result = mtu }
-		.suspendCancellable()
+		.suspendNonCancellable()
 	return result!!
 }
 
@@ -203,7 +216,7 @@ suspend fun PhyRequest.suspend(): Pair<Int, Int> {
 	var result: Pair<Int, Int>? = null
 	this
 		.with { _, txPhy, rxPhy -> result = txPhy to rxPhy }
-		.suspendCancellable()
+		.suspendNonCancellable()
 	return result!!
 }
 
@@ -219,6 +232,7 @@ suspend fun PhyRequest.suspend(): Pair<Int, Int> {
 	InvalidRequestException::class
 )
 suspend fun WaitForValueChangedRequest.suspend(): Data  = suspendCancellableCoroutine { continuation ->
+	continuation.invokeOnCancellation { cancel() }
 	var data: Data? = null
 	this
 		// DON'T USE .before callback here, it's used to get BluetoothDevice instance above.
@@ -226,6 +240,7 @@ suspend fun WaitForValueChangedRequest.suspend(): Data  = suspendCancellableCoro
 		.invalid { continuation.resumeWithException(InvalidRequestException(this)) }
 		.fail { _, status ->
 			val exception = when (status) {
+				FailCallback.REASON_CANCELLED -> return@fail
 				FailCallback.REASON_BLUETOOTH_DISABLED -> BluetoothDisabledException()
 				FailCallback.REASON_DEVICE_DISCONNECTED -> DeviceDisconnectedException()
 				else -> RequestFailedException(this, status)
@@ -300,6 +315,7 @@ suspend inline fun <reified T: ProfileReadResponse> WaitForValueChangedRequest.s
 	InvalidRequestException::class
 )
 suspend fun WaitForReadRequest.suspend(): Data  = suspendCancellableCoroutine { continuation ->
+	continuation.invokeOnCancellation { cancel() }
 	var data: Data?	= null
 	this
 		// Make sure the callbacks are called without unnecessary delay.
@@ -309,6 +325,7 @@ suspend fun WaitForReadRequest.suspend(): Data  = suspendCancellableCoroutine { 
 		.invalid { continuation.resumeWithException(InvalidRequestException(this)) }
 		.fail { _, status ->
 			val exception = when (status) {
+				FailCallback.REASON_CANCELLED -> return@fail
 				FailCallback.REASON_BLUETOOTH_DISABLED -> BluetoothDisabledException()
 				FailCallback.REASON_DEVICE_DISCONNECTED -> DeviceDisconnectedException()
 				else -> RequestFailedException(this, status)
@@ -349,13 +366,27 @@ suspend inline fun <reified T: WriteResponse> WaitForReadRequest.suspendForRespo
 		}
 }
 
-private suspend fun Request.suspendCancellable(): Unit = suspendCancellableCoroutine { continuation ->
-	if (this is TimeoutableRequest) {
-		continuation.invokeOnCancellation { cancel() }
-	}
-	// Note, that other requests are not cancellable.
-	// All BLE calls has to wait for the result, so there is no way to cancel them.
+private suspend fun SimpleRequest.suspendNonCancellable() = suspendCoroutine { continuation ->
+	this
+		// Make sure the callbacks are called without unnecessary delay.
+		.setHandler(null)
+		// DON'T USE .before callback here, it's used to get BluetoothDevice instance above.
+		.invalid { continuation.resumeWithException(InvalidRequestException(this)) }
+		.fail { _, status ->
+			val exception = when (status) {
+				FailCallback.REASON_BLUETOOTH_DISABLED -> BluetoothDisabledException()
+				FailCallback.REASON_DEVICE_DISCONNECTED -> DeviceDisconnectedException()
+				else -> RequestFailedException(this, status)
+			}
+			continuation.resumeWithException(exception)
+		}
+		.done { continuation.resume(Unit) }
+		// .then is called after both .done and .fail
+		.enqueue()
+}
 
+private suspend fun TimeoutableRequest.suspendCancellable() = suspendCancellableCoroutine { continuation ->
+	continuation.invokeOnCancellation { cancel() }
 	this
 		// Make sure the callbacks are called without unnecessary delay.
 		.setHandler(null)

--- a/ble/src/main/java/no/nordicsemi/android/ble/AwaitingRequest.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/AwaitingRequest.java
@@ -6,6 +6,9 @@ import android.bluetooth.BluetoothGattDescriptor;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+
+import java.util.concurrent.CancellationException;
+
 import no.nordicsemi.android.ble.exception.BluetoothDisabledException;
 import no.nordicsemi.android.ble.exception.DeviceDisconnectedException;
 import no.nordicsemi.android.ble.exception.InvalidRequestException;
@@ -63,7 +66,7 @@ public abstract class AwaitingRequest<T> extends TimeoutableValueRequest<T> {
 	@Override
 	public <E extends T> E await(@NonNull final E response)
 			throws RequestFailedException, DeviceDisconnectedException, BluetoothDisabledException,
-			InvalidRequestException, InterruptedException {
+			InvalidRequestException, InterruptedException, CancellationException {
 		assertNotMainThread();
 
 		try {

--- a/ble/src/main/java/no/nordicsemi/android/ble/BleManagerHandler.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/BleManagerHandler.java
@@ -1325,7 +1325,14 @@ abstract class BleManagerHandler extends RequestHandler {
 	final void cancelQueue() {
 		taskQueue.clear();
 		initQueue = null;
+
 		cancelCurrent();
+
+		if (connectRequest != null && bluetoothDevice != null) {
+			connectRequest.notifyFail(bluetoothDevice, FailCallback.REASON_CANCELLED);
+			connectRequest = null;
+			internalDisconnect(ConnectionObserver.REASON_CANCELLED);
+		}
 	}
 
 	@Override
@@ -1351,13 +1358,7 @@ abstract class BleManagerHandler extends RequestHandler {
 			requestQueue.notifyFail(device, FailCallback.REASON_CANCELLED);
 			requestQueue = null;
 		}
-		if (connectRequest != null) {
-			connectRequest.notifyFail(device, FailCallback.REASON_CANCELLED);
-			connectRequest = null;
-			internalDisconnect(ConnectionObserver.REASON_CANCELLED);
-		} else {
-			nextRequest(request == null);
-		}
+		nextRequest(request == null);
 	}
 
 	@Override

--- a/ble/src/main/java/no/nordicsemi/android/ble/BleManagerHandler.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/BleManagerHandler.java
@@ -1326,10 +1326,16 @@ abstract class BleManagerHandler extends RequestHandler {
 		taskQueue.clear();
 		initQueue = null;
 
-		cancelCurrent();
+		final BluetoothDevice device = bluetoothDevice;
+		if (device == null)
+			return;
 
-		if (connectRequest != null && bluetoothDevice != null) {
-			connectRequest.notifyFail(bluetoothDevice, FailCallback.REASON_CANCELLED);
+		if (operationInProgress) {
+			cancelCurrent();
+		}
+
+		if (connectRequest != null) {
+			connectRequest.notifyFail(device, FailCallback.REASON_CANCELLED);
 			connectRequest = null;
 			internalDisconnect(ConnectionObserver.REASON_CANCELLED);
 		}
@@ -1343,7 +1349,6 @@ abstract class BleManagerHandler extends RequestHandler {
 		}
 		if (request instanceof TimeoutableRequest) {
 			request.notifyFail(device, FailCallback.REASON_CANCELLED);
-			request = null;
 		}
 		if (awaitingRequest != null) {
 			awaitingRequest.notifyFail(device, FailCallback.REASON_CANCELLED);
@@ -1358,7 +1363,7 @@ abstract class BleManagerHandler extends RequestHandler {
 			requestQueue.notifyFail(device, FailCallback.REASON_CANCELLED);
 			requestQueue = null;
 		}
-		nextRequest(request == null);
+		nextRequest(request == null || request.finished);
 	}
 
 	@Override
@@ -1368,7 +1373,6 @@ abstract class BleManagerHandler extends RequestHandler {
 		}
 		if (request instanceof TimeoutableRequest) {
 			request.notifyFail(device, FailCallback.REASON_TIMEOUT);
-			request = null;
 		}
 		if (awaitingRequest != null) {
 			awaitingRequest.notifyFail(device, FailCallback.REASON_TIMEOUT);
@@ -1385,7 +1389,7 @@ abstract class BleManagerHandler extends RequestHandler {
 			close();
 			return;
 		}
-		nextRequest(request == null);
+		nextRequest(request == null || request.finished);
 	}
 
 	@Override

--- a/ble/src/main/java/no/nordicsemi/android/ble/RequestHandler.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/RequestHandler.java
@@ -1,5 +1,7 @@
 package no.nordicsemi.android.ble;
 
+import android.bluetooth.BluetoothDevice;
+
 import androidx.annotation.NonNull;
 
 abstract class RequestHandler implements CallbackHandler {
@@ -20,9 +22,17 @@ abstract class RequestHandler implements CallbackHandler {
 	abstract void cancelQueue();
 
 	/**
+	 * Cancels current {@link TimeoutableRequest}.
+	 */
+	abstract void cancelCurrent();
+
+	/**
 	 * Method called when the request timed out.
 	 *
 	 * @param request the request that timed out.
 	 */
-	abstract void onRequestTimeout(@NonNull final TimeoutableRequest request);
+	abstract void onRequestTimeout(
+			@NonNull final BluetoothDevice device,
+			@NonNull final TimeoutableRequest request
+	);
 }

--- a/ble/src/main/java/no/nordicsemi/android/ble/SimpleRequest.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/SimpleRequest.java
@@ -83,6 +83,9 @@ public class SimpleRequest extends Request {
 		final SuccessCallback sc = successCallback;
 		final FailCallback fc = failCallback;
 		try {
+			if (finished || enqueued) {
+				throw new IllegalStateException();
+			}
 			syncLock.close();
 			final RequestCallback callback = new RequestCallback();
 			beforeCallback = null;

--- a/ble/src/main/java/no/nordicsemi/android/ble/SleepRequest.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/SleepRequest.java
@@ -27,18 +27,18 @@ import android.os.Handler;
 import androidx.annotation.IntRange;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+
 import no.nordicsemi.android.ble.callback.AfterCallback;
 import no.nordicsemi.android.ble.callback.BeforeCallback;
 import no.nordicsemi.android.ble.callback.FailCallback;
 import no.nordicsemi.android.ble.callback.InvalidRequestCallback;
 import no.nordicsemi.android.ble.callback.SuccessCallback;
 
-public final class SleepRequest extends SimpleRequest implements Operation {
-	private final long delay;
+public final class SleepRequest extends TimeoutableRequest implements Operation {
 
 	SleepRequest(@NonNull final Type type, @IntRange(from = 0) final long delay) {
 		super(type);
-		this.delay = delay;
+		this.timeout = delay;
 	}
 
     @NonNull
@@ -90,7 +90,10 @@ public final class SleepRequest extends SimpleRequest implements Operation {
 		return this;
 	}
 
-	long getDelay() {
-		return delay;
+	@NonNull
+	@Override
+	public SleepRequest timeout(@IntRange(from = 0) final long timeout) {
+		super.timeout(timeout);
+		return this;
 	}
 }

--- a/ble/src/main/java/no/nordicsemi/android/ble/TimeoutableRequest.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/TimeoutableRequest.java
@@ -9,6 +9,9 @@ import android.os.Handler;
 import androidx.annotation.IntRange;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+
+import java.util.concurrent.CancellationException;
+
 import no.nordicsemi.android.ble.callback.FailCallback;
 import no.nordicsemi.android.ble.callback.SuccessCallback;
 import no.nordicsemi.android.ble.exception.BluetoothDisabledException;
@@ -16,8 +19,18 @@ import no.nordicsemi.android.ble.exception.DeviceDisconnectedException;
 import no.nordicsemi.android.ble.exception.InvalidRequestException;
 import no.nordicsemi.android.ble.exception.RequestFailedException;
 
+/**
+ * A base class for requests that can be canceled or can time out.
+ * <p>
+ * Not all messages can be cancelled. For example, Bluetooth LE operations, which rely on
+ * {@link android.bluetooth.BluetoothGattCallback} callbacks, cannot be cancelled. This is because
+ * the callback is called when the operation is completed, even if the request was cancelled.
+ * Receiving the callback is required before starting a new operation.
+ */
 public abstract class TimeoutableRequest extends Request {
+	@Nullable
 	private Runnable timeoutCallback;
+	protected boolean cancelled;
 	protected long timeout;
 
 	TimeoutableRequest(@NonNull final Type type) {
@@ -65,6 +78,23 @@ public abstract class TimeoutableRequest extends Request {
 	}
 
 	/**
+	 * Cancels the request. The request will fail with {@link FailCallback#REASON_CANCELLED},
+	 * or will throw {@link CancellationException} if the thread is blocked using {@link #await()}.
+	 * <p>
+	 * If the request has not been started yet, it will be skipped silently.
+	 */
+	public void cancel() {
+		if (!started) {
+			// The request has not been started yet. It will be skipped.
+			cancelled = true;
+			finished = true;
+		} else if (!finished) {
+			cancelled = true;
+			requestHandler.cancelCurrent();
+		}
+	}
+
+	/**
 	 * Enqueues the request for asynchronous execution.
 	 * <p>
 	 * Use {@link #timeout(long)} to set the maximum time the manager should wait until the device
@@ -106,6 +136,7 @@ public abstract class TimeoutableRequest extends Request {
 	 *                                     than {@link BluetoothGatt#GATT_SUCCESS}.
 	 * @throws InterruptedException        thrown if the timeout occurred before the request has
 	 *                                     finished.
+	 * @throws CancellationException       thrown when the request has been cancelled.
 	 * @throws IllegalStateException       thrown when you try to call this method from the main
 	 *                                     (UI) thread.
 	 * @throws DeviceDisconnectedException thrown when the device disconnected before the request
@@ -130,6 +161,9 @@ public abstract class TimeoutableRequest extends Request {
 				throw new InterruptedException();
 			}
 			if (!callback.isSuccess()) {
+				if (callback.status == FailCallback.REASON_CANCELLED) {
+					throw new CancellationException();
+				}
 				if (callback.status == FailCallback.REASON_DEVICE_DISCONNECTED) {
 					throw new DeviceDisconnectedException();
 				}
@@ -164,6 +198,7 @@ public abstract class TimeoutableRequest extends Request {
 	 *                                     than {@link BluetoothGatt#GATT_SUCCESS}.
 	 * @throws InterruptedException        thrown if the timeout occurred before the request has
 	 *                                     finished.
+	 * @throws CancellationException       thrown when the request has been cancelled.
 	 * @throws IllegalStateException       thrown when you try to call this method from the main
 	 *                                     (UI) thread.
 	 * @throws DeviceDisconnectedException thrown when the device disconnected before the request
@@ -176,7 +211,7 @@ public abstract class TimeoutableRequest extends Request {
 	@Deprecated
 	public final void await(@IntRange(from = 0) final long timeout) throws RequestFailedException,
 			InterruptedException, DeviceDisconnectedException, BluetoothDisabledException,
-			InvalidRequestException {
+			InvalidRequestException, CancellationException {
 		timeout(timeout).await();
 	}
 
@@ -186,8 +221,7 @@ public abstract class TimeoutableRequest extends Request {
 			timeoutCallback = () -> {
 				timeoutCallback = null;
 				if (!finished) {
-					notifyFail(device, FailCallback.REASON_TIMEOUT);
-					requestHandler.onRequestTimeout(this);
+					requestHandler.onRequestTimeout(device, this);
 				}
 			};
 			handler.postDelayed(timeoutCallback, timeout);
@@ -197,7 +231,7 @@ public abstract class TimeoutableRequest extends Request {
 
 	@Override
 	boolean notifySuccess(@NonNull final BluetoothDevice device) {
-		if (!finished) {
+		if (timeoutCallback != null) {
 			handler.removeCallbacks(timeoutCallback);
 			timeoutCallback = null;
 		}
@@ -206,7 +240,7 @@ public abstract class TimeoutableRequest extends Request {
 
 	@Override
 	void notifyFail(@NonNull final BluetoothDevice device, final int status) {
-		if (!finished) {
+		if (timeoutCallback != null) {
 			handler.removeCallbacks(timeoutCallback);
 			timeoutCallback = null;
 		}
@@ -215,10 +249,19 @@ public abstract class TimeoutableRequest extends Request {
 
 	@Override
 	void notifyInvalidRequest() {
-		if (!finished) {
+		if (timeoutCallback != null) {
 			handler.removeCallbacks(timeoutCallback);
 			timeoutCallback = null;
 		}
 		super.notifyInvalidRequest();
+	}
+
+	/**
+	 * Returns true if the request has been cancelled.
+	 *
+	 * @return true if the request has been cancelled.
+	 */
+	public final boolean isCancelled() {
+		return cancelled;
 	}
 }

--- a/ble/src/main/java/no/nordicsemi/android/ble/TimeoutableRequest.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/TimeoutableRequest.java
@@ -150,6 +150,12 @@ public abstract class TimeoutableRequest extends Request {
 			BluetoothDisabledException, InvalidRequestException, InterruptedException {
 		assertNotMainThread();
 
+		if (cancelled) {
+			throw new CancellationException();
+		}
+		if (finished || enqueued) {
+			throw new IllegalStateException();
+		}
 		final SuccessCallback sc = successCallback;
 		final FailCallback fc = failCallback;
 		try {

--- a/ble/src/main/java/no/nordicsemi/android/ble/TimeoutableValueRequest.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/TimeoutableValueRequest.java
@@ -28,6 +28,9 @@ import android.bluetooth.BluetoothGattDescriptor;
 import androidx.annotation.IntRange;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+
+import java.util.concurrent.CancellationException;
+
 import no.nordicsemi.android.ble.callback.FailCallback;
 import no.nordicsemi.android.ble.callback.SuccessCallback;
 import no.nordicsemi.android.ble.exception.BluetoothDisabledException;
@@ -95,6 +98,7 @@ public abstract class TimeoutableValueRequest<T> extends TimeoutableRequest {
 	 *                                     than {@link android.bluetooth.BluetoothGatt#GATT_SUCCESS}.
 	 * @throws InterruptedException        thrown if the timeout occurred before the request has
 	 *                                     finished.
+	 * @throws CancellationException       thrown when the request has been cancelled.
 	 * @throws IllegalStateException       thrown when you try to call this method from the main
 	 *                                     (UI) thread, or when the trigger was already enqueued.
 	 * @throws DeviceDisconnectedException thrown when the device disconnected before the request
@@ -106,7 +110,7 @@ public abstract class TimeoutableValueRequest<T> extends TimeoutableRequest {
 	@NonNull
 	public <E extends T> E await(@NonNull final E response)
 			throws RequestFailedException, DeviceDisconnectedException, BluetoothDisabledException,
-			InvalidRequestException, InterruptedException {
+			InvalidRequestException, InterruptedException, CancellationException {
 		assertNotMainThread();
 
 		final T vc = valueCallback;
@@ -133,6 +137,7 @@ public abstract class TimeoutableValueRequest<T> extends TimeoutableRequest {
 	 *                                     than {@link android.bluetooth.BluetoothGatt#GATT_SUCCESS}.
 	 * @throws InterruptedException        thrown if the timeout occurred before the request has
 	 *                                     finished.
+	 * @throws CancellationException       thrown when the request has been cancelled.
 	 * @throws IllegalStateException       thrown when you try to call this method from the main
 	 *                                     (UI) thread.
 	 * @throws IllegalArgumentException    thrown when the response class could not be instantiated.
@@ -146,7 +151,7 @@ public abstract class TimeoutableValueRequest<T> extends TimeoutableRequest {
 	@NonNull
 	public <E extends T> E await(@NonNull final Class<E> responseClass)
 			throws RequestFailedException, DeviceDisconnectedException, BluetoothDisabledException,
-			InvalidRequestException, InterruptedException {
+			InvalidRequestException, InterruptedException, CancellationException {
 		assertNotMainThread();
 
 		try {
@@ -182,6 +187,7 @@ public abstract class TimeoutableValueRequest<T> extends TimeoutableRequest {
 	 *                                     than {@link android.bluetooth.BluetoothGatt#GATT_SUCCESS}.
 	 * @throws InterruptedException        thrown if the timeout occurred before the request has
 	 *                                     finished.
+	 * @throws CancellationException       thrown when the request has been cancelled.
 	 * @throws IllegalStateException       thrown when you try to call this method from the main
 	 *                                     (UI) thread.
 	 * @throws IllegalArgumentException    thrown when the response class could not be instantiated.
@@ -197,7 +203,7 @@ public abstract class TimeoutableValueRequest<T> extends TimeoutableRequest {
 	public <E extends T> E await(@NonNull final Class<E> responseClass,
 								 @IntRange(from = 0) final long timeout)
 			throws RequestFailedException, InterruptedException, DeviceDisconnectedException,
-			BluetoothDisabledException, InvalidRequestException {
+			BluetoothDisabledException, InvalidRequestException, CancellationException {
 		return timeout(timeout).await(responseClass);
 	}
 
@@ -218,6 +224,7 @@ public abstract class TimeoutableValueRequest<T> extends TimeoutableRequest {
 	 *                                     than {@link android.bluetooth.BluetoothGatt#GATT_SUCCESS}.
 	 * @throws InterruptedException        thrown if the timeout occurred before the request has
 	 *                                     finished.
+	 * @throws CancellationException       thrown when the request has been cancelled.
 	 * @throws IllegalStateException       thrown when you try to call this method from the main
 	 *                                     (UI) thread.
 	 * @throws DeviceDisconnectedException thrown when the device disconnected before the request
@@ -232,7 +239,7 @@ public abstract class TimeoutableValueRequest<T> extends TimeoutableRequest {
 	public <E extends T> E await(@NonNull final E response,
 								 @IntRange(from = 0) final long timeout)
 			throws RequestFailedException, InterruptedException, DeviceDisconnectedException,
-			BluetoothDisabledException, InvalidRequestException {
+			BluetoothDisabledException, InvalidRequestException, CancellationException {
 		return timeout(timeout).await(response);
 	}
 }

--- a/ble/src/main/java/no/nordicsemi/android/ble/WaitForValueChangedRequest.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/WaitForValueChangedRequest.java
@@ -31,6 +31,9 @@ import android.util.Log;
 import androidx.annotation.IntRange;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+
+import java.util.concurrent.CancellationException;
+
 import no.nordicsemi.android.ble.callback.AfterCallback;
 import no.nordicsemi.android.ble.callback.BeforeCallback;
 import no.nordicsemi.android.ble.callback.DataReceivedCallback;
@@ -212,6 +215,7 @@ public final class WaitForValueChangedRequest extends AwaitingRequest<DataReceiv
 	 *                                     the main (UI) thread.
 	 * @throws InterruptedException        thrown when the timeout occurred before the
 	 *                                     characteristic value has changed.
+	 * @throws CancellationException       thrown when the request has been cancelled.
 	 * @throws RequestFailedException      thrown when the trigger request has failed.
 	 * @throws DeviceDisconnectedException thrown when the device disconnected before the
 	 *                                     notification or indication was received.
@@ -227,7 +231,8 @@ public final class WaitForValueChangedRequest extends AwaitingRequest<DataReceiv
 	@NonNull
 	public <E extends ProfileReadResponse> E awaitValid(@NonNull final E response)
 			throws RequestFailedException, InvalidDataException, DeviceDisconnectedException,
-			BluetoothDisabledException, InvalidRequestException, InterruptedException {
+			BluetoothDisabledException, InvalidRequestException, InterruptedException,
+			CancellationException{
 		final E result = await(response);
 		if (result != null && !result.isValid()) {
 			throw new InvalidDataException(result);
@@ -248,6 +253,7 @@ public final class WaitForValueChangedRequest extends AwaitingRequest<DataReceiv
 	 *                                     the main (UI) thread.
 	 * @throws InterruptedException        thrown when the timeout occurred before the
 	 *                                     characteristic value has changed.
+	 * @throws CancellationException       thrown when the request has been cancelled.
 	 * @throws IllegalArgumentException    thrown when the response class could not be instantiated.
 	 * @throws RequestFailedException      thrown when the trigger request has failed.
 	 * @throws DeviceDisconnectedException thrown when the device disconnected before the
@@ -264,7 +270,8 @@ public final class WaitForValueChangedRequest extends AwaitingRequest<DataReceiv
 	@NonNull
 	public <E extends ProfileReadResponse> E awaitValid(@NonNull final Class<E> responseClass)
 			throws RequestFailedException, InvalidDataException, DeviceDisconnectedException,
-			BluetoothDisabledException, InvalidRequestException, InterruptedException {
+			BluetoothDisabledException, InvalidRequestException, InterruptedException,
+			CancellationException {
 		final E response = await(responseClass);
 		if (response != null && !response.isValid()) {
 			throw new InvalidDataException(response);
@@ -285,6 +292,7 @@ public final class WaitForValueChangedRequest extends AwaitingRequest<DataReceiv
 	 *                                     the main (UI) thread.
 	 * @throws InterruptedException        thrown when the timeout occurred before the
 	 *                                     characteristic value has changed.
+	 * @throws CancellationException       thrown when the request has been cancelled.
 	 * @throws IllegalArgumentException    thrown when the response class could not be instantiated.
 	 * @throws RequestFailedException      thrown when the trigger request has failed.
 	 * @throws DeviceDisconnectedException thrown when the device disconnected before the
@@ -303,7 +311,8 @@ public final class WaitForValueChangedRequest extends AwaitingRequest<DataReceiv
 	public <E extends ProfileReadResponse> E awaitValid(@NonNull final Class<E> responseClass,
 														@IntRange(from = 0) final long timeout)
 			throws InterruptedException, InvalidDataException, RequestFailedException,
-			DeviceDisconnectedException, BluetoothDisabledException, InvalidRequestException {
+			DeviceDisconnectedException, BluetoothDisabledException, InvalidRequestException,
+			CancellationException {
 		return timeout(timeout).awaitValid(responseClass);
 	}
 
@@ -319,6 +328,7 @@ public final class WaitForValueChangedRequest extends AwaitingRequest<DataReceiv
 	 *                                     the main (UI) thread.
 	 * @throws InterruptedException        thrown when the timeout occurred before the
 	 *                                     characteristic value has changed.
+	 * @throws CancellationException       thrown when the request has been cancelled.
 	 * @throws RequestFailedException      thrown when the trigger request has failed.
 	 * @throws DeviceDisconnectedException thrown when the device disconnected before the
 	 *                                     notification or indication was received.
@@ -336,7 +346,8 @@ public final class WaitForValueChangedRequest extends AwaitingRequest<DataReceiv
 	public <E extends ProfileReadResponse> E awaitValid(@NonNull final E response,
 														@IntRange(from = 0) final long timeout)
 			throws InterruptedException, InvalidDataException, DeviceDisconnectedException,
-			RequestFailedException, BluetoothDisabledException, InvalidRequestException {
+			RequestFailedException, BluetoothDisabledException, InvalidRequestException,
+			CancellationException{
 		return timeout(timeout).awaitValid(response);
 	}
 


### PR DESCRIPTION
This PR adds support for cancellation of selected requests.

### Important

Bluetooth LE requests, which extend `SimpleRequest` cannot be cancelled. In Android API, each `BluetoothGatt` method triggers corresponding call in `BluetoothGattCallback`.

### Changes

#### ble
* New `cancel()` method added to `TimetoutableRequest`.
* `RequestQueue` now extends `TimeoutableRequest` making it and `ReliableWriteRequest` both cancellable and timetable. Mind, that `SimpleRequest`s added to those queues won't be cancelled, but the queue itself can be.
* `SleepRequest` now extends `TimeoutableRequest` and the timeout is used as waking up mechanism (eacbad45f98c5299b5e805f8ab8b186635a25832).
* A request that has completed or was cancelled cannot be enqueued again (each request can be enqueued just once).
* Logging improvement - logs related to awaiting requests have been added (e40cbd49fd316396637b676e6e44b745d80d069a).
* Kinda breaking: A request enqueued in `initialize()` (during connecting) and cancelled does not cancel the `ConnectRequest` itself.

#### ble-ktx
* Cancelling a coroutine suspended on a `TimeoutableRequest` will trigger the request to be cancelled.