### PR TITLE
Data provider for read requests

### DIFF
--- a/ble/src/main/java/no/nordicsemi/android/ble/BleManager.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/BleManager.java
@@ -54,6 +54,7 @@ import no.nordicsemi.android.ble.annotation.PhyMask;
 import no.nordicsemi.android.ble.annotation.PhyOption;
 import no.nordicsemi.android.ble.annotation.WriteType;
 import no.nordicsemi.android.ble.callback.ConnectionParametersUpdatedCallback;
+import no.nordicsemi.android.ble.data.DataProvider;
 import no.nordicsemi.android.ble.observer.BondingObserver;
 import no.nordicsemi.android.ble.observer.ConnectionObserver;
 import no.nordicsemi.android.ble.callback.ConnectionPriorityCallback;
@@ -997,8 +998,10 @@ public abstract class BleManager implements ILogger {
 	/**
 	 * Waits until the given characteristic is read by the remote device. The data must have been set
 	 * to the characteristic before the request is executed.
-	 * Use {@link #setCharacteristicValue(BluetoothGattCharacteristic, Data)} to set data, or
-	 * {@link #waitForRead(BluetoothGattCharacteristic, byte[], int, int)} to set the data immediately.
+	 * Use {@link #setCharacteristicValue(BluetoothGattCharacteristic, Data)} to set data,
+	 * {@link #waitForRead(BluetoothGattCharacteristic, byte[], int, int)} to set the data immediately,
+	 * or {@link #setCharacteristicValue(BluetoothGattCharacteristic, DataProvider)} to set the
+	 * data on demand.
 	 * <p>
 	 * The returned request must be either enqueued using {@link Request#enqueue()} for
 	 * asynchronous use, or awaited using await() in synchronous execution.
@@ -1053,8 +1056,9 @@ public abstract class BleManager implements ILogger {
 	/**
 	 * Waits until the given descriptor is read by the remote device. The data must have been set
 	 * to the descriptor before the request is executed.
-	 * Use {@link #setDescriptorValue(BluetoothGattDescriptor, byte[])} to set data, or
-	 * {@link #waitForRead(BluetoothGattDescriptor, byte[], int, int)} to set the data immediately.
+	 * Use {@link #setDescriptorValue(BluetoothGattDescriptor, byte[])} to set data,
+	 * {@link #waitForRead(BluetoothGattDescriptor, byte[], int, int)} to set the data immediately,
+	 * or {@link #setDescriptorValue(BluetoothGattDescriptor, DataProvider)} to set the
 	 * <p>
 	 * The returned request must be either enqueued using {@link Request#enqueue()} for
 	 * asynchronous use, or awaited using await() in synchronous execution.
@@ -1104,6 +1108,24 @@ public abstract class BleManager implements ILogger {
 											 @Nullable final byte[] data, final int offset, final int length) {
 		return Request.newWaitForReadRequest(serverDescriptor, data, offset, length)
 				.setRequestHandler(requestHandler);
+	}
+
+	/**
+	 * Sets the data provider to the given readable server characteristic.
+	 * <p>
+	 * The provider will be called when the remote device sends a read command to the given
+	 * characteristic. This allows returning current value without the need to update the value
+	 * periodically.
+	 * <p>
+	 * If the provider is not set, the value set using
+	 * {@link #setCharacteristicValue(BluetoothGattCharacteristic, Data)} will be returned.
+	 *
+	 * @param serverCharacteristic the target characteristic to provide data for.
+	 * @param provider the data provider for the given characteristic.
+	 */
+	protected void setCharacteristicValue(@Nullable final BluetoothGattCharacteristic serverCharacteristic,
+										  @Nullable final DataProvider provider) {
+		requestHandler.setCharacteristicValue(serverCharacteristic, provider);
 	}
 
 	/**
@@ -1161,6 +1183,24 @@ public abstract class BleManager implements ILogger {
 													 @Nullable final byte[] data, final int offset, final int length) {
 		return Request.newSetValueRequest(serverCharacteristic, data, offset, length)
 				.setRequestHandler(requestHandler);
+	}
+
+	/**
+	 * Sets the data provider to the given readable server descriptor.
+	 * <p>
+	 * The provider will be called when the remote device sends a read command to the given
+	 * descriptor. This allows returning current value without the need to update the value
+	 * periodically.
+	 * <p>
+	 * If the provider is not set, the value set using
+	 * {@link #setDescriptorValue(BluetoothGattDescriptor, Data)} will be returned.
+	 *
+	 * @param serverDescriptor the target descriptor to provide data for.
+	 * @param provider the data provider for the given characteristic.
+	 */
+	protected void setDescriptorValue(@Nullable final BluetoothGattDescriptor serverDescriptor,
+									  @Nullable final DataProvider provider) {
+		requestHandler.setDescriptorValue(serverDescriptor, provider);
 	}
 
 	/**

--- a/ble/src/main/java/no/nordicsemi/android/ble/WaitForReadRequest.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/WaitForReadRequest.java
@@ -205,8 +205,8 @@ public final class WaitForReadRequest extends AwaitingRequest<DataSentCallback> 
 			return data != null ? data : new byte[] {};
 		}
 
-		// Read [procedure requires 3 bytes for handler and op code.
-		final int maxLength = mtu - 3;
+		// Max length of read response is ATT_MTU - 1 (opcode).
+		final int maxLength = mtu - 1;
 
 		byte[] chunk = nextChunk;
 		// Get the first chunk.

--- a/ble/src/main/java/no/nordicsemi/android/ble/data/DataProvider.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/data/DataProvider.java
@@ -1,0 +1,25 @@
+package no.nordicsemi.android.ble.data;
+
+import android.bluetooth.BluetoothDevice;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+public interface DataProvider {
+
+    /**
+     * Returns the data that should be returned as Read response.
+     * <p>
+     * The data can be longer than MTU-1, but must not be longer than 512 bytes:
+     * <pre>
+     * Bluetooth LE Core Specification, version 5.2, Vol 3, Part F
+     * Chapter 3.2.9: Long attribute values
+     * "The maximum length of an attribute value shall be 512 octets."
+     * </pre>
+     *
+     * @param device the target device.
+     * @return the data to be sent.
+     */
+    @Nullable
+    byte[] getData(@NonNull final BluetoothDevice device);
+}


### PR DESCRIPTION
This PR solves #385.

So far, when setting up a readable server characteristic (or descriptor), there were 2 options to provide a value for a read request sent from a client:
1. Using `setCharacteristicValue(...)` request:
https://github.com/NordicSemiconductor/Android-BLE-Library/blob/2f1fb7b39e420a57e3ce8f8e1eb3e05b7e4170ac/ble/src/main/java/no/nordicsemi/android/ble/BleManager.java#L1120-L1125 
2. Using `waitForRead(...)` request:
https://github.com/NordicSemiconductor/Android-BLE-Library/blob/2f1fb7b39e420a57e3ce8f8e1eb3e05b7e4170ac/ble/src/main/java/no/nordicsemi/android/ble/BleManager.java#L1009-L1013

However, as described in the issue mentioned above, sometimes a live value needs to be provided. The server would have to update the characteristic value using 1. periodically even if no client reads the value, just to keep it up to date.

This PR adds a new, third way for providing the characteristic (or descriptor) value:
https://github.com/NordicSemiconductor/Android-BLE-Library/blob/3ec87475d5b1607464cd0f6546c067ec01847c87/ble/src/main/java/no/nordicsemi/android/ble/BleManager.java#L1126-L1130

The registered `DataProvider` will be asked to provide current value of an attribute whenever a read request is received for this attribute.

The interface is very simple:
https://github.com/NordicSemiconductor/Android-BLE-Library/blob/3ec87475d5b1607464cd0f6546c067ec01847c87/ble/src/main/java/no/nordicsemi/android/ble/data/DataProvider.java#L10-L24

As the max length for any value is 512 bytes, this method should not return longer data. Packets longer than `MTU-1` will be automatically split into chunks. 

### Note:

The data returned by `DataProvider` will be sent using a single *Read Characteristic Value* procedure, or using *Read Long Characteristic Value*. For sending longer packets, it is recommended either to use notifications, or `waitForRead(..)` (2.) approach, where a `DataSplitter` can be set. Each chunk given from a splitter is sent using *Read Characteristic Value* procedure, so the client needs to actively send read requests until the complete data is read. It is up to the user to design how client need to know when to stop polling. Usually, a header in a first read response, or a flag in each response is used for that purpose.