### PR TITLE
Bug fix: `createBondInsecure()` cannot be suspended

### DIFF
--- a/ble-ktx/src/main/java/no/nordicsemi/android/ble/ktx/RequestSuspend.kt
+++ b/ble-ktx/src/main/java/no/nordicsemi/android/ble/ktx/RequestSuspend.kt
@@ -25,7 +25,7 @@ import kotlin.coroutines.suspendCoroutine
 	RequestFailedException::class,
 	InvalidRequestException::class
 )
-suspend fun SimpleRequest.suspend() = suspendNonCancellable()
+suspend fun Request.suspend() = suspendNonCancellable()
 
 /**
  * Suspends the coroutine until the request is completed.
@@ -366,7 +366,7 @@ suspend inline fun <reified T: WriteResponse> WaitForReadRequest.suspendForRespo
 		}
 }
 
-private suspend fun SimpleRequest.suspendNonCancellable() = suspendCoroutine { continuation ->
+private suspend fun Request.suspendNonCancellable() = suspendCoroutine { continuation ->
 	this
 		// Make sure the callbacks are called without unnecessary delay.
 		.setHandler(null)


### PR DESCRIPTION
This PR fixes an issue introduced in recent alpha versions, where the `suspend()` method in `ble-ktx` has been split into 2: cancelable and non-cancelable.
The latter one has been set as an extension to `SimpleRequest` (all BLE commands), but not to `Request`, leaving creation on bond without `suspend()` support.