### PR TITLE
Don't verify write without response operations

### DIFF
--- a/ble/src/main/java/no/nordicsemi/android/ble/WriteRequest.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/WriteRequest.java
@@ -275,7 +275,7 @@ public final class WriteRequest extends SimpleValueRequest<DataSentCallback> imp
 		handler.post(() -> {
 			if (progressCallback != null) {
 				try {
-					progressCallback.onPacketSent(device, data, count);
+					progressCallback.onPacketSent(device, currentChunk, count);
 				} catch (final Throwable t) {
 					Log.e(TAG, "Exception in Progress callback", t);
 				}
@@ -293,7 +293,13 @@ public final class WriteRequest extends SimpleValueRequest<DataSentCallback> imp
 				}
 			});
 		}
-		return Arrays.equals(data, currentChunk);
+		if (writeType == BluetoothGattCharacteristic.WRITE_TYPE_DEFAULT) {
+			// Compare the data received with the data sent.
+			return Arrays.equals(data, currentChunk);
+		} else {
+			// Don't check the data when using Write Without Response.
+			return true;
+		}
 	}
 
 	/**


### PR DESCRIPTION
When doing Reliable Write, the client is responsible for verifying the written data. This has sense, actually, only when Write With Response is used. In this case the device confirms the data sent.

This PR removes the check when write type is not `BluetoothGattCharacteristic.WRITE_TYPE_DEFAULT`.