### PR TITLE
Server connection events

### DIFF
--- a/ble/src/main/java/no/nordicsemi/android/ble/BleManagerHandler.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/BleManagerHandler.java
@@ -463,6 +463,12 @@ abstract class BleManagerHandler extends RequestHandler {
 	 *  handler.
 	 */
 	void attachClientConnection(BluetoothDevice clientDevice) {
+		final BleServerManager serverManager = this.serverManager;
+		if (serverManager == null) {
+			log(Log.ERROR, () -> "Server not bound to the manager");
+			return;
+		}
+
 		// should either setup as server only (this method) or two way connection (connect method), not both
 		if (this.bluetoothDevice != null) {
 			log(Log.ERROR, () -> "attachClientConnection called on existing connection, call ignored");
@@ -477,6 +483,7 @@ abstract class BleManagerHandler extends RequestHandler {
 	}
 
 	private void initializeServerAttributes() {
+		final BleServerManager serverManager = this.serverManager;
 		if (serverManager != null) {
 			final BluetoothGattServer server = serverManager.getServer();
 			if (server != null) {

--- a/ble/src/main/java/no/nordicsemi/android/ble/BleServerManager.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/BleServerManager.java
@@ -168,6 +168,7 @@ public abstract class BleServerManager implements ILogger {
 	 * After calling this method, the server will not disconnect after few seconds.
 	 * @param device The device to connect.
 	 * @param autoConnect Should the device automatically reconnect after it was disconnected.
+	 * @noinspection SameParameterValue
 	 */
 	final void useConnection(@NonNull final BluetoothDevice device, final boolean autoConnect) {
 		if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S ||


### PR DESCRIPTION
This PR fixes #506. At least I hope so. @nadrolinux, please check.

 When a server disconnection event is received and corresponding `BleManager` exists, the server manager will call `notifyDeviceDisconnected(...)`, which should reset the states to `STATE_DISCONNECTED` and notify the requests.

Also, when the server manager was set for a `BleManager`, and the device is used as client (that is `connect(..)` is used, the manager now calls `connect(..)` method in the `BluetoothGattServer`. This should make the connection reference persistent in the server. I don't think this is necessary, as it was working before, but should work with it as well.