### PR TITLE
Reconnection fixed

### DIFF
--- a/ble/src/main/java/no/nordicsemi/android/ble/BleManagerHandler.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/BleManagerHandler.java
@@ -82,7 +82,7 @@ abstract class BleManagerHandler extends RequestHandler {
 
 	private final Object LOCK = new Object();
 	private BluetoothDevice bluetoothDevice;
-	private BluetoothGatt bluetoothGatt;
+	/* package */ BluetoothGatt bluetoothGatt;
 	private BleManager manager;
 	private BleServerManager serverManager;
 	private Handler handler;

--- a/ble/src/main/java/no/nordicsemi/android/ble/BleServerManager.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/BleServerManager.java
@@ -738,7 +738,9 @@ public abstract class BleServerManager implements ILogger {
 					log(Log.WARN, "[Server] " + device.getAddress() + " has disconnected connected with status: " + status);
 				}
 				final BleManagerHandler handler = getRequestHandler(device);
-				if (handler != null) {
+				if (handler != null && handler.bluetoothGatt == null) {
+					// There is no client connection to the device.
+					// We have to notify disconnection manually.
 					handler.notifyDeviceDisconnected(device, status);
 				}
 				if (serverObserver != null)


### PR DESCRIPTION
This PR fixes #526.

I think this is minimal required change to fix the issue. The call to `notifyDeviceDisconnected(...)` was added to `BleServerManager` in #521. It was supposed to fix no disconnection callback in server-only mode when `attachClientConnection` is used.

However, as @corentin-c noticed, that broke bidirectional connection, as that method is now called twice, from server and client, and client doesn't reconnect.

The proposed check ensures that it is called only in server-only mode when `bluetoothGatt` object is null.