### PR TITLE
Fixed restoring connection state after cancelled connection attempt

### DIFF
--- a/ble/src/main/java/no/nordicsemi/android/ble/BleManagerHandler.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/BleManagerHandler.java
@@ -1856,6 +1856,7 @@ abstract class BleManagerHandler extends RequestHandler {
 			return;
 
 		final boolean wasConnected = connected;
+		final boolean hadDiscoveredServices = servicesDiscovered;
 		connected = false;
 		ready = false;
 		servicesDiscovered = false;
@@ -1906,7 +1907,9 @@ abstract class BleManagerHandler extends RequestHandler {
 		dataProviders.clear();
 		batteryLevelNotificationCallback = null;
 		batteryValue = -1;
-		manager.onServicesInvalidated();
+		if (hadDiscoveredServices) {
+			manager.onServicesInvalidated();
+		}
 		onDeviceDisconnected();
 	}
 


### PR DESCRIPTION
This PR fixes #524.

When the first connection attempt fails, and the library will start to retry connection, this code is invoked:
https://github.com/NordicSemiconductor/Android-BLE-Library/blob/53e169ec7dec77923c50619967b895e8a91091aa/ble/src/main/java/no/nordicsemi/android/ble/BleManagerHandler.java#L639-L648
If the `ConnectRequest` times out, or gets cancelled when the thread is waiting 200 ms, the connection was cancelled, but `connectionState` was never set back to `STATE_DISCONNECTED`.

This PR fixes that by checking the value of `bluetoothGatt` reference after `internalConnect` is called.
In case of *null*, that is when `connectRequest.finished` was *true*, the state is reset to disconnected.

Also, this PR adds another change. When the connection attempt fails, the `onServicesInvalidated()` is not called, as there were no services to invalidate in the first place. This MAY be breaking for some, but I hope not.