### PR TITLE
Fix autoConnect true not working with Android 14 after the second disconnection

### DIFF
--- a/ble/src/main/java/no/nordicsemi/android/ble/BleManagerHandler.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/BleManagerHandler.java
@@ -647,17 +647,31 @@ abstract class BleManagerHandler extends RequestHandler {
 						// Ignore
 					}
 				} else {
-					// Instead, the gatt.connect() method will be used to reconnect to the same device.
-					// This method forces autoConnect = true even if the gatt was created with this
-					// flag set to false.
 					initialConnection = false;
 					connectionTime = 0L; // no timeout possible when autoConnect used
 					connectionState = BluetoothGatt.STATE_CONNECTING;
 					log(Log.VERBOSE, () -> "Connecting...");
 					postCallback(c -> c.onDeviceConnecting(device));
 					postConnectionStateChange(o -> o.onDeviceConnecting(device));
-					log(Log.DEBUG, () -> "gatt.connect()");
-					bluetoothGatt.connect();
+					if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+                        int preferredPhy = PhyRequest.PHY_LE_1M_MASK;
+                        if(connectRequest != null) {
+                            preferredPhy = connectRequest.getPreferredPhy();
+                        }
+                        final int finalPreferredPhy = preferredPhy;
+                        log(Log.DEBUG, () ->
+                                "gatt = device.connectGatt(autoConnect = true, TRANSPORT_LE, "
+                                        + ParserUtils.phyMaskToString(finalPreferredPhy) + ")");
+                        bluetoothGatt = device.connectGatt(context, true, gattCallback,
+                                BluetoothDevice.TRANSPORT_LE, finalPreferredPhy, handler);
+
+					} else {
+						// Instead, the gatt.connect() method will be used to reconnect to the same device.
+						// This method forces autoConnect = true (except on Android 14) even if the gatt was
+                        // created with this flag set to false.
+						log(Log.DEBUG, () -> "gatt.connect()");
+						bluetoothGatt.connect();
+					}
 					return true;
 				}
 			} else {

--- a/ble/src/main/java/no/nordicsemi/android/ble/BleManagerHandler.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/BleManagerHandler.java
@@ -653,7 +653,7 @@ abstract class BleManagerHandler extends RequestHandler {
 					log(Log.VERBOSE, () -> "Connecting...");
 					postCallback(c -> c.onDeviceConnecting(device));
 					postConnectionStateChange(o -> o.onDeviceConnecting(device));
-					if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+					if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
                         int preferredPhy = PhyRequest.PHY_LE_1M_MASK;
                         if(connectRequest != null) {
                             preferredPhy = connectRequest.getPreferredPhy();
@@ -663,8 +663,7 @@ abstract class BleManagerHandler extends RequestHandler {
                                 "gatt = device.connectGatt(autoConnect = true, TRANSPORT_LE, "
                                         + ParserUtils.phyMaskToString(finalPreferredPhy) + ")");
                         bluetoothGatt = device.connectGatt(context, true, gattCallback,
-                                BluetoothDevice.TRANSPORT_LE, finalPreferredPhy, handler);
-
+                                BluetoothDevice.TRANSPORT_LE, preferredPhy, handler);
 					} else {
 						// Instead, the gatt.connect() method will be used to reconnect to the same device.
 						// This method forces autoConnect = true (except on Android 14) even if the gatt was


### PR DESCRIPTION
Hi,

### The issue :
I have been testing Android 14 with bidirectionnal client and server connection, using BleManager.connect with `autoConnect = true` to connect to a Ble device, it works great with all versions below, but seems to be broken on Android 14. I can connect with it, the first disconnection and reconnection works, but after the second disconnection, the device never reconnects.

### The cause :
From what I understand, if autoconnect is used with true, the library first connects with autoConnect false. Then the library uses `gatt.connect()` on the first disconnection to trigger the autoconnect to true. The problem seems that the `gatt.connect()` on Android 14 does not do the same as before, it doesn't set autoConnect to true and works only for the next connection. So after the second disconnection, the device does not reconnect anymore.

### Diagnosis :
I first noticed that on the first disconnection on Android 14, we have a log not present on previous Android versions :

> Connecting...
> 10:36:10.030  D  gatt.connect()
> 10:36:10.031  D  connect(void) - device: XX:XX:XX:XX:6D:DE, auto=false // HERE

It seems like its autoconnecting with false here. It can only reconnect once after this.

So I have been playing with autoconnect without the library and Android 14 : 
- If I connect with first autoconnect false, then `gatt.connect` after the first disconnection, it behave like I mentioned before and doesn't reconnect after the second disconnection
- If I connect with first autoconnect false, then `autoconnect = true` after the first disconnection it works

### Fix :
To fix it, use a connectGatt with autoConnect = true if we detect Android 14 on the phone.