### PR TITLE
Make the bluetoothDevice value immutable before the null check

### DIFF
--- a/ble/src/main/java/no/nordicsemi/android/ble/BleManagerHandler.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/BleManagerHandler.java
@@ -740,6 +740,7 @@ abstract class BleManagerHandler extends RequestHandler {
 		ready = false;
 
 		final BleServerManager serverManager = this.serverManager;
+		final BluetoothDevice bluetoothDevice = this.bluetoothDevice;
 		if (serverManager != null && bluetoothDevice != null) {
 			log(Log.VERBOSE, () -> "Cancelling server connection...");
 			log(Log.DEBUG, () -> "server.cancelConnection(device)");

--- a/ble/src/main/java/no/nordicsemi/android/ble/BleServerManager.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/BleServerManager.java
@@ -185,8 +185,9 @@ public abstract class BleServerManager implements ILogger {
 	 * @param device The device to cancel connection to.
 	 */
 	final void cancelConnection(@NonNull final BluetoothDevice device) {
-		if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S ||
-				context.checkCallingOrSelfPermission(Manifest.permission.BLUETOOTH_CONNECT) == PackageManager.PERMISSION_GRANTED) {
+		if (server != null &&
+				(Build.VERSION.SDK_INT < Build.VERSION_CODES.S ||
+				context.checkCallingOrSelfPermission(Manifest.permission.BLUETOOTH_CONNECT) == PackageManager.PERMISSION_GRANTED)) {
 			server.cancelConnection(device);
 		}
 	}


### PR DESCRIPTION
Make the bluetoothDevice value immutable before the null check to fix this request https://github.com/NordicSemiconductor/Android-BLE-Library/issues/539