### PR TITLE
Provide access to cancelConnection so that a server can deny a client

### DIFF
--- a/ble/src/main/java/no/nordicsemi/android/ble/BleServerManager.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/BleServerManager.java
@@ -182,9 +182,11 @@ public abstract class BleServerManager implements ILogger {
 	 * <p>
 	 * As we're not calling {@link BluetoothGattServer#connect(BluetoothDevice, boolean)}, cancelling
 	 * the connection should not be required. On the other hand, perhaps we should call connect(..).
+	 * Can also be called in onDeviceConnectedToServer to refuse a device connection without accepting it first.
+	 * If you already have a managed connection and want to disconnect, you can use the disconnect request on the connection.
 	 * @param device The device to cancel connection to.
 	 */
-	final void cancelConnection(@NonNull final BluetoothDevice device) {
+	protected final void cancelConnection(@NonNull final BluetoothDevice device) {
 		if (server != null &&
 				(Build.VERSION.SDK_INT < Build.VERSION_CODES.S ||
 				context.checkCallingOrSelfPermission(Manifest.permission.BLUETOOTH_CONNECT) == PackageManager.PERMISSION_GRANTED)) {


### PR DESCRIPTION
Stumbled across a situation where I want my server to block access to a client device but cannot find a way to disconnect it without first accepting it to build the managed connection. If there is a way I missed, please let me know. I can reflect into the library to get to `cancelConnection` for now but would be nice if there was legit access to it.

This is the basic scenario.

```kotlin
override fun onDeviceConnectedToServer(device: BluetoothDevice) {
    val address = device.address
    if (allowed(address)) {
        val newConnection = ...
        newConnection.useServer(this)
        newConnection.attachClientConnection(device)        
    } else {
        Log.d(TAG, "BLE connection blocked $address")
        cancelConnection(device)
    }
}
```
