### PR TITLE
fix: remove_bond request should be handled after disconnect

### DIFF
--- a/ble/src/main/java/no/nordicsemi/android/ble/BleManagerHandler.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/BleManagerHandler.java
@@ -2286,6 +2286,12 @@ abstract class BleManagerHandler extends RequestHandler {
 
 					// Reset flag, so the next Connect could be enqueued.
 					operationInProgress = false;
+
+					// return because Request.Type.REMOVE_BOND not handled
+					if (r != null && r.type == Request.Type.REMOVE_BOND) {
+						return;
+					}
+
 					// Try to reconnect if the initial connection was lost because of a link loss,
 					// and shouldAutoConnect() returned true during connection attempt.
 					// This time it will set the autoConnect flag to true (gatt.connect() forces


### PR DESCRIPTION
this PR is about to fix #363 case 1, `this.request` will reset to `null` in call of `nextRequest(false)` below and callback for `removeBond` won't be invoked correctly even though bond status change signal is received later. how ever it may introduce unintended side effects as noted in the comment above. Please help to review it.

https://github.com/NordicSemiconductor/Android-BLE-Library/blob/bfcfdf9f5916ac2b06c9de6ed335b11dc53301c2/ble/src/main/java/no/nordicsemi/android/ble/BleManagerHandler.java#L2200-L2212