### PR TITLE
Bug fix: Auto connect not restarting if the initial connection fails when using with a non-bonded device

### DIFF
--- a/ble/src/main/java/no/nordicsemi/android/ble/BleManagerHandler.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/BleManagerHandler.java
@@ -2215,8 +2215,7 @@ abstract class BleManagerHandler extends RequestHandler {
 						return;
 					}
 
-					if (cr != null && cr.shouldAutoConnect() && initialConnection
-							&& gatt.getDevice().getBondState() == BluetoothDevice.BOND_BONDED) {
+					if (cr != null && cr.shouldAutoConnect() && initialConnection) {
 						log(Log.DEBUG, () -> "autoConnect = false called failed; retrying with autoConnect = true" + (connected ? "; reset connected to false" : ""));
 
 						// fix：https://github.com/NordicSemiconductor/Android-BLE-Library/issues/497


### PR DESCRIPTION
If using `useAutoConnect(true)`:
```
manager.connect(bluetoothDevice)
        .useAutoConnect(true)
        .suspend()
```

the initial connection will be a normal one (calling `connectGatt()` with `autoConnect = false`). If this fails (times out), the next connect is supposed to use auto connect (with `bluetoothGatt.connect()` or calling `connectGatt()` with `autoConnect = true`).

However, this does not work with a non-bonded device. As mentioned in the Javadoc of `useAutoConnect(true)`, auto connect is still viable to use without a bond when the BLE device has a private static address.

This PR fixes the issue by removing the check for bond in the disconnected state handling.

I believe this is also the cause of this reported issue - https://github.com/NordicSemiconductor/Android-BLE-Library/issues/435