### PR TITLE
Start auto connect immediately

### DIFF
--- a/ble/src/main/java/no/nordicsemi/android/ble/BleManagerHandler.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/BleManagerHandler.java
@@ -741,6 +741,10 @@ abstract class BleManagerHandler extends RequestHandler {
 			log(Log.DEBUG, () -> "gatt = device.connectGatt(autoConnect = " + autoConnect + ")");
 			bluetoothGatt = device.connectGatt(context, autoConnect, gattCallback);
 		}
+
+		if (autoConnect && this.connectRequest != null) {
+			this.connectRequest.notifySuccess(device);
+		}
 		return true;
 	}
 

--- a/ble/src/main/java/no/nordicsemi/android/ble/BleManagerHandler.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/BleManagerHandler.java
@@ -706,10 +706,12 @@ abstract class BleManagerHandler extends RequestHandler {
 		userDisconnected = !shouldAutoConnect;
 
 		bluetoothDevice = device;
-		log(Log.VERBOSE, () -> connectRequest.isFirstAttempt() ? "Connecting..." : "Retrying...");
-		connectionState = BluetoothGatt.STATE_CONNECTING;
-		postCallback(c -> c.onDeviceConnecting(device));
-		postConnectionStateChange(o -> o.onDeviceConnecting(device));
+		if (!autoConnect) {
+			log(Log.VERBOSE, () -> connectRequest.isFirstAttempt() ? "Connecting..." : "Retrying...");
+			connectionState = BluetoothGatt.STATE_CONNECTING;
+			postCallback(c -> c.onDeviceConnecting(device));
+			postConnectionStateChange(o -> o.onDeviceConnecting(device));
+		}
 		connectionTime = SystemClock.elapsedRealtime();
 		if (Build.VERSION.SDK_INT > Build.VERSION_CODES.O) {
 			// connectRequest will never be null here.

--- a/ble/src/main/java/no/nordicsemi/android/ble/BleManagerHandler.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/BleManagerHandler.java
@@ -744,6 +744,7 @@ abstract class BleManagerHandler extends RequestHandler {
 
 		if (autoConnect && this.connectRequest != null) {
 			this.connectRequest.notifySuccess(device);
+			this.connectRequest = null;
 		}
 		return true;
 	}

--- a/ble/src/main/java/no/nordicsemi/android/ble/ConnectRequest.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/ConnectRequest.java
@@ -210,6 +210,41 @@ public class ConnectRequest extends TimeoutableRequest {
 		return this;
 	}
 
+	/**
+	 * Sets whether to connect to the remote device just once (autoConnect == false) or to add
+	 * the address to white list of devices that will be automatically connect as soon as they
+	 * become available (autoConnect == true). In the latter case, if Bluetooth adapter is enabled,
+	 * Android scans periodically for devices from the white list and, if an advertising packet
+	 * is received from such, it tries to connect to it.
+	 * When the connection is lost, the system will keep trying to reconnect to
+	 * it. If method is called with autoConnect set to true, and the connection to the device is
+	 * lost, the {@link BleManagerCallbacks#onLinkLossOccurred(BluetoothDevice)} callback is
+	 * called instead of {@link BleManagerCallbacks#onDeviceDisconnected(BluetoothDevice)}.
+	 * <p>
+	 * This feature works much better on newer Android phone models and may have issues on older
+	 * phones.
+	 * <p>
+	 * This method should only be used with bonded devices, as otherwise the device may change
+	 * it's address. It will however work also with non-bonded devices with private static address.
+	 * A connection attempt to a non-bonded device with private resolvable address will fail.
+	 * <p>
+	 * If createDirectConnectionFirst is set to true, the first connection to a device will always be
+	 * created with autoConnect flag to false
+	 * (see {@link BluetoothDevice#connectGatt(Context, boolean, BluetoothGattCallback)}). This is
+	 * to make it quick as the user most probably waits for a quick response. If autoConnect is
+	 * used (true), the following connections will be done using {@link BluetoothGatt#connect()},
+	 * which forces the autoConnect parameter to true.
+	 * If autoConnect is used (true) and createDirectConnectionFirst is set to false, the connection
+	 * to a device will be created with autoConnect flag to true from the start.
+	 *
+	 * @param autoConnect                 true to use autoConnect feature.
+	 * @param createDirectConnectionFirst If true, the first connection is always done with autoConnect
+	 *                                    parameter equal to false, to make it faster and allow to timeout
+	 *                                    if the device is unreachable.
+	 *                                    If false, the connection to a device will be created with
+	 *                                    autoConnect flag to true from the start.
+	 * @return The request.
+	 */
 	public ConnectRequest useAutoConnect(final boolean autoConnect, final boolean createDirectConnectionFirst) {
 		this.autoConnect = autoConnect;
 		this.autoConnectCreateDirectConnectionFirst = createDirectConnectionFirst;

--- a/ble/src/main/java/no/nordicsemi/android/ble/ConnectRequest.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/ConnectRequest.java
@@ -60,6 +60,7 @@ public class ConnectRequest extends TimeoutableRequest {
 	@IntRange(from = 0)
 	private int delay = 0;
 	private boolean autoConnect = false;
+	private boolean autoConnectCreateDirectConnectionFirst = true;
 
 	ConnectRequest(@NonNull final Type type, @NonNull final BluetoothDevice device) {
 		super(type);
@@ -209,6 +210,12 @@ public class ConnectRequest extends TimeoutableRequest {
 		return this;
 	}
 
+	public ConnectRequest useAutoConnect(final boolean autoConnect, final boolean createDirectConnectionFirst) {
+		this.autoConnect = autoConnect;
+		this.autoConnectCreateDirectConnectionFirst = createDirectConnectionFirst;
+		return this;
+	}
+
 	/**
 	 * Sets the preferred PHY used for connection. The value should be a bitmask composed of
 	 * {@link PhyRequest#PHY_LE_1M_MASK}, {@link PhyRequest#PHY_LE_2M_MASK} or
@@ -292,5 +299,9 @@ public class ConnectRequest extends TimeoutableRequest {
 
 	boolean shouldAutoConnect() {
 		return autoConnect;
+	}
+
+	boolean shouldAutoConnectCreateDirectConnectionFirst() {
+		return autoConnectCreateDirectConnectionFirst;
 	}
 }


### PR DESCRIPTION
This is an addition to the auto connect mechanism that offers a different approach while keeping the current API as-is.

The current approach for auto connect is such that the first connection attempt is made using a direct connect (`connectGatt()` with `autoConnect` set to `false`).
This opinionated approach does not fit some use cases well. The main problem being that if the device is not nearby / connectable when the `ConnectRequest` with `useAutoConnect(true)` is enqueued, this will occupy the BLE stack for 30 seconds until timeout (consuming more battery unnecessarily). Scanning for the device first would help with this, but that defeats the purpose of using auto connect (essentially letting the system do the scanning more efficiently).
A secondary problem being that the first connect (and disconnect) behaves differently then any following one (`ConnectionRequest` completes after the first one, connection state changes are different etc.), which is hard to handle because of the inconsistency.

This was also discussed in the passed in https://github.com/NordicSemiconductor/Android-BLE-Library/issues/435#issuecomment-1295881176

I have added a new `useAutoConnect()` with `createDirectConnectionFirst` parameter where you can choose to start the auto connect mechanism from the start, skipping the initial direct connection.

The idea is to not change the existing behavior for users of the library. The default behavior is therefore to use the existing approach.

If this can be improved in any way, please let me know and I can change it.