### PR TITLE
Registering broadcast receivers as exported

### DIFF
--- a/ble/build.gradle
+++ b/ble/build.gradle
@@ -33,6 +33,7 @@ android {
 
 dependencies {
     api 'androidx.annotation:annotation:1.8.2'
+    implementation 'androidx.core:core:1.13.1'
 
     testImplementation 'junit:junit:4.13.2'
 }

--- a/ble/src/main/java/no/nordicsemi/android/ble/BleManager.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/BleManager.java
@@ -47,6 +47,8 @@ import androidx.annotation.RequiresApi;
 import androidx.annotation.RequiresPermission;
 import androidx.annotation.RestrictTo;
 import androidx.annotation.StringRes;
+import androidx.core.content.ContextCompat;
+
 import no.nordicsemi.android.ble.annotation.ConnectionPriority;
 import no.nordicsemi.android.ble.annotation.ConnectionState;
 import no.nordicsemi.android.ble.annotation.LogPriority;
@@ -178,9 +180,10 @@ public abstract class BleManager implements ILogger {
 		this.requestHandler = getGattCallback();
 		this.requestHandler.init(this, handler);
 
-		context.registerReceiver(mPairingRequestBroadcastReceiver,
+		ContextCompat.registerReceiver(context, mPairingRequestBroadcastReceiver,
 				// BluetoothDevice.ACTION_PAIRING_REQUEST
-				new IntentFilter("android.bluetooth.device.action.PAIRING_REQUEST"));
+				new IntentFilter("android.bluetooth.device.action.PAIRING_REQUEST"),
+				ContextCompat.RECEIVER_EXPORTED);
 	}
 
 	/**

--- a/ble/src/main/java/no/nordicsemi/android/ble/BleManagerHandler.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/BleManagerHandler.java
@@ -29,6 +29,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.RequiresApi;
 import androidx.annotation.RequiresPermission;
+import androidx.core.content.ContextCompat;
 
 import java.lang.reflect.Method;
 import java.security.InvalidParameterException;
@@ -677,10 +678,10 @@ abstract class BleManagerHandler extends RequestHandler {
 			} else {
 				if (connectRequest != null) {
 					// Register bonding broadcast receiver
-					context.registerReceiver(bluetoothStateBroadcastReceiver,
-							new IntentFilter(BluetoothAdapter.ACTION_STATE_CHANGED));
-					context.registerReceiver(mBondingBroadcastReceiver,
-							new IntentFilter(BluetoothDevice.ACTION_BOND_STATE_CHANGED));
+					ContextCompat.registerReceiver(context, bluetoothStateBroadcastReceiver,
+							new IntentFilter(BluetoothAdapter.ACTION_STATE_CHANGED), ContextCompat.RECEIVER_EXPORTED);
+					ContextCompat.registerReceiver(context, mBondingBroadcastReceiver,
+							new IntentFilter(BluetoothDevice.ACTION_BOND_STATE_CHANGED), ContextCompat.RECEIVER_EXPORTED);
 				}
 			}
 		}

--- a/examples/ble-gatt-server/src/main/java/no/nordicsemi/android/ble/ble_gatt_server/GattService.kt
+++ b/examples/ble-gatt-server/src/main/java/no/nordicsemi/android/ble/ble_gatt_server/GattService.kt
@@ -34,6 +34,7 @@ import android.os.Binder
 import android.os.IBinder
 import android.util.Log
 import androidx.core.app.NotificationCompat
+import androidx.core.content.ContextCompat
 import no.nordicsemi.android.ble.BleManager
 import no.nordicsemi.android.ble.BleServerManager
 import no.nordicsemi.android.ble.observer.ServerObserver
@@ -111,7 +112,9 @@ class GattService : Service() {
                 }
             }
         }
-        registerReceiver(bluetoothObserver, IntentFilter(BluetoothAdapter.ACTION_STATE_CHANGED))
+        ContextCompat.registerReceiver(this,
+            bluetoothObserver, IntentFilter(BluetoothAdapter.ACTION_STATE_CHANGED),
+            ContextCompat.RECEIVER_EXPORTED)
 
         // Startup BLE if we have it
 


### PR DESCRIPTION
Although the system broadcasts are exported automatically, it's better to set the `RECEIVER_EXPORTED` flag explicitly.