### PR TITLE
add permission BLUETOOTH_ADMIN

### DIFF
--- a/examples/ble-gatt-server/src/main/AndroidManifest.xml
+++ b/examples/ble-gatt-server/src/main/AndroidManifest.xml
@@ -6,6 +6,8 @@
     <!-- Legacy Bluetooth permissions -->
     <uses-permission android:name="android.permission.BLUETOOTH"
         android:maxSdkVersion="30"/>
+    <uses-permission android:name="android.permission.BLUETOOTH_ADMIN"
+        android:maxSdkVersion="30"/>
     <!-- New Bluetooth permissions -->
     <uses-permission android:name="android.permission.BLUETOOTH_ADVERTISE" />
     <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />


### PR DESCRIPTION
If I launched `ble-gatt-server` app on Android Phone, failed to launch app.
The cause was a lack of permission in AndroidManifest.xml.

Android phone spec is below.
- Galaxy S20
- Android 11

I add `BLUETOOTH_ADMIN` permission to AndroidManifest.xml.