### PR TITLE
Bugfix: Packet mergers in sample apps

### DIFF
--- a/examples/trivia/src/main/java/no/nordicsemi/android/ble/trivia/spec/PacketMerger.kt
+++ b/examples/trivia/src/main/java/no/nordicsemi/android/ble/trivia/spec/PacketMerger.kt
@@ -24,6 +24,10 @@ class PacketMerger : DataMerger {
         if (lastPacket == null)
             return false
 
+        if (index == 0) {
+            receivedDataSize = 0
+        }
+
         val buffer = ByteBuffer.wrap(lastPacket)
         receivedDataSize += buffer.remaining()
 
@@ -33,7 +37,7 @@ class PacketMerger : DataMerger {
         ByteArray(buffer.remaining())
             .apply { buffer.get(this) }
             .also { output.write(it) }
-        return receivedDataSize - 2 == expectedSize
+        return receivedDataSize - 2 >= expectedSize
     }
 
 }

--- a/examples/trivia/src/main/java/no/nordicsemi/android/ble/trivia/spec/PacketMerger.kt
+++ b/examples/trivia/src/main/java/no/nordicsemi/android/ble/trivia/spec/PacketMerger.kt
@@ -6,37 +6,34 @@ import java.nio.ByteBuffer
 
 class PacketMerger : DataMerger {
     private var expectedSize = 0
+    private var receivedDataSize = 0
 
     /**
-     * A method that merges the last packet into the output message. All bytes from the lastPacket
-     * are simply copied to the output stream until null is returned.
+     * A method that merges the last packet into the output message.
+     * If its a fist packet, the first two bytes of the packet contain a header which includes the expected size
+     * of the message to be received. The remaining bytes of the packet contain the message, which is copied to the output stream.
+     * For all subsequent packets, the message bytes are simply copied to the output stream
+     * until the size of the packet received matches the expected size of the message delivered through header file.
      *
      * @param output     the stream for the output message, initially empty.
      * @param lastPacket the data received in the last read/notify/indicate operation.
      * @param index      an index of the packet, 0-based.
-     * @return True,    if the message is complete, false if more data are expected.
+     * @return True, if the message is complete, false if more data are expected.
      */
     override fun merge(output: DataStream, lastPacket: ByteArray?, index: Int): Boolean {
         if (lastPacket == null)
             return false
 
         val buffer = ByteBuffer.wrap(lastPacket)
+        receivedDataSize += buffer.remaining()
 
         if (index == 0) {
             expectedSize = buffer.short.toInt()
         }
-
-        if (buffer.remaining() == expectedSize) {
-            ByteArray(expectedSize)
-                .apply { buffer.get(this) }
-                .also { output.write(it) }
-                .let { return true }
-        } else {
-            ByteArray(buffer.remaining())
-                .apply { buffer.get(this) }
-                .also { output.write(it) }
-                .let { return false }
-        }
+        ByteArray(buffer.remaining())
+            .apply { buffer.get(this) }
+            .also { output.write(it) }
+        return receivedDataSize - 2 == expectedSize
     }
 
 }

--- a/test/src/main/java/no/nordicsemi/andorid/ble/test/spec/HeaderBasedPacketMerger.kt
+++ b/test/src/main/java/no/nordicsemi/andorid/ble/test/spec/HeaderBasedPacketMerger.kt
@@ -24,6 +24,10 @@ class HeaderBasedPacketMerger: DataMerger {
         if (lastPacket == null)
             return false
 
+        if (index == 0) {
+            receivedDataSize = 0
+        }
+
         val buffer = ByteBuffer.wrap(lastPacket)
         receivedDataSize += buffer.remaining()
 
@@ -33,7 +37,7 @@ class HeaderBasedPacketMerger: DataMerger {
         ByteArray(buffer.remaining())
             .apply { buffer.get(this) }
             .also { output.write(it) }
-        return receivedDataSize - 2 == expectedSize
+        return receivedDataSize - 2 >= expectedSize
     }
 
 }


### PR DESCRIPTION
This PR fixes #584 and fixes the packet mergers in _trivia_ and _test_ apps.