### PR TITLE
Making WriteRequest and ReadRequest timeoutable amd cancellable

### DIFF
--- a/ble/src/main/java/no/nordicsemi/android/ble/ReadRequest.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/ReadRequest.java
@@ -51,7 +51,7 @@ import no.nordicsemi.android.ble.exception.InvalidRequestException;
 import no.nordicsemi.android.ble.exception.RequestFailedException;
 
 @SuppressWarnings({"unused", "WeakerAccess"})
-public final class ReadRequest extends SimpleValueRequest<DataReceivedCallback> implements Operation  {
+public final class ReadRequest extends TimeoutableValueRequest<DataReceivedCallback> implements Operation  {
 	private ReadProgressCallback progressCallback;
 	private DataMerger dataMerger;
 	private DataStream buffer;
@@ -198,6 +198,8 @@ public final class ReadRequest extends SimpleValueRequest<DataReceivedCallback> 
 	 * @return The object with the response.
 	 * @throws RequestFailedException      thrown when the BLE request finished with status other
      *                                     than {@link BluetoothGatt#GATT_SUCCESS}.
+	 * @throws InterruptedException        thrown if the timeout occurred before the request has
+	 *                                     finished.
 	 * @throws IllegalStateException       thrown when you try to call this method from the main
      *                                     (UI) thread.
 	 * @throws IllegalArgumentException    thrown when the response class could not be instantiated.
@@ -214,7 +216,7 @@ public final class ReadRequest extends SimpleValueRequest<DataReceivedCallback> 
 	@NonNull
 	public <E extends ProfileReadResponse> E awaitValid(@NonNull final Class<E> responseClass)
 			throws RequestFailedException, InvalidDataException, DeviceDisconnectedException,
-			BluetoothDisabledException, InvalidRequestException {
+			BluetoothDisabledException, InterruptedException, InvalidRequestException {
 		final E response = await(responseClass);
 		if (!response.isValid()) {
 			throw new InvalidDataException(response);
@@ -232,6 +234,8 @@ public final class ReadRequest extends SimpleValueRequest<DataReceivedCallback> 
 	 * @return The object with the response.
      * @throws RequestFailedException      thrown when the BLE request finished with status other
      *                                     than {@link BluetoothGatt#GATT_SUCCESS}.
+	 * @throws InterruptedException        thrown if the timeout occurred before the request has
+	 *                                     finished.
      * @throws IllegalStateException       thrown when you try to call this method from the main
      *                                     (UI) thread.
 	 * @throws DeviceDisconnectedException thrown when the device disconnected before the request
@@ -247,7 +251,7 @@ public final class ReadRequest extends SimpleValueRequest<DataReceivedCallback> 
 	@NonNull
 	public <E extends ProfileReadResponse> E awaitValid(@NonNull final E response)
 			throws RequestFailedException, InvalidDataException, DeviceDisconnectedException,
-			BluetoothDisabledException, InvalidRequestException {
+			BluetoothDisabledException, InterruptedException, InvalidRequestException {
 		await(response);
 		if (!response.isValid()) {
 			throw new InvalidDataException(response);
@@ -315,6 +319,6 @@ public final class ReadRequest extends SimpleValueRequest<DataReceivedCallback> 
 
 	@SuppressWarnings("BooleanMethodIsAlwaysInverted")
 	boolean hasMore() {
-		return !complete;
+		return !complete && !cancelled && !finished;
 	}
 }

--- a/ble/src/main/java/no/nordicsemi/android/ble/WriteRequest.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/WriteRequest.java
@@ -47,7 +47,7 @@ import no.nordicsemi.android.ble.data.DataSplitter;
 import no.nordicsemi.android.ble.data.DefaultMtuSplitter;
 
 @SuppressWarnings({"unused", "WeakerAccess"})
-public final class WriteRequest extends SimpleValueRequest<DataSentCallback> implements Operation {
+public final class WriteRequest extends TimeoutableValueRequest<DataSentCallback> implements Operation {
 	private final static DataSplitter MTU_SPLITTER = new DefaultMtuSplitter();
 
 	private WriteProgressCallback progressCallback;
@@ -310,7 +310,7 @@ public final class WriteRequest extends SimpleValueRequest<DataSentCallback> imp
 	 * @return True if not all data were sent, false if the request is complete.
 	 */
 	boolean hasMore() {
-		return !complete;
+		return !complete && !cancelled && !finished;
 	}
 
 	/**


### PR DESCRIPTION
This PR makes the `WriteRequest` and `ReadRequest` cancellable. These requests can only be canceled if they consist of multiple BLE operations, that is `split` or `merge` are used. Cancellation will abort sending or waiting for more packets, but it will not stop the one that is already in progress (due to Android API requirements).