### PR TITLE
Trigger service discovery if interrupted in `onConnectionUpdated`

### DIFF
--- a/ble/src/main/java/no/nordicsemi/android/ble/BleManagerHandler.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/BleManagerHandler.java
@@ -2907,6 +2907,11 @@ abstract class BleManagerHandler extends RequestHandler {
 					cpr.notifyConnectionPriorityChanged(gatt.getDevice(), interval, latency, timeout);
 					cpr.notifySuccess(gatt.getDevice());
 				}
+				if (serviceDiscoveryRequested) {
+					log(Log.VERBOSE, () -> "Discovering services...");
+					log(Log.DEBUG, () -> "gatt.discoverServices()");
+					bluetoothGatt.discoverServices();
+				}
 			} else if (status == 0x3b) { // HCI_ERR_UNACCEPT_CONN_INTERVAL
 				Log.e(TAG, "onConnectionUpdated received status: Unacceptable connection interval, " +
 						"interval: " + interval + ", latency: " + latency + ", timeout: " + timeout);


### PR DESCRIPTION
It appears that when a service discovery is in progress and `onConnectionUpdated` is called, the service discovery callback `onServicesDiscovered` is never invoked. By checking to see `serviceDiscoverRequested` is set, we can restart the service discovery and get a result back.

This may potentially fix #536, but I was seeing this behaviour consistently when connecting to another BLE device