### PR TITLE
Dependencies updated

### DIFF
--- a/ble-common/build.gradle
+++ b/ble-common/build.gradle
@@ -4,11 +4,11 @@ plugins {
 
 android {
     namespace 'no.nordicsemi.android.ble.common'
-    compileSdk 34
+    compileSdk 35
 
     defaultConfig {
         minSdk 18
-        targetSdk 34
+        targetSdk 35
     }
 
     buildTypes {

--- a/ble-ktx/build.gradle
+++ b/ble-ktx/build.gradle
@@ -5,11 +5,11 @@ plugins {
 
 android {
     namespace 'no.nordicsemi.android.ble.ktx'
-    compileSdk 34
+    compileSdk 35
 
     defaultConfig {
         minSdk 18
-        targetSdk 34
+        targetSdk 35
     }
 
     buildTypes {

--- a/ble-ktx/build.gradle
+++ b/ble-ktx/build.gradle
@@ -38,7 +38,7 @@ android {
 
 dependencies {
     api project(':ble')
-    api 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.9.0'
+    api 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.10.1'
 }
 
 // === Maven Central configuration ===

--- a/ble-livedata/build.gradle
+++ b/ble-livedata/build.gradle
@@ -4,11 +4,11 @@ plugins {
 
 android {
     namespace 'no.nordicsemi.android.ble.livedata'
-    compileSdk 34
+    compileSdk 35
 
     defaultConfig {
         minSdk 18
-        targetSdk 34
+        targetSdk 35
     }
 
     buildTypes {

--- a/ble-livedata/build.gradle
+++ b/ble-livedata/build.gradle
@@ -35,7 +35,7 @@ dependencies {
     api project(':ble')
 
     // https://developer.android.com/jetpack/androidx/releases/lifecycle
-    api 'androidx.lifecycle:lifecycle-livedata:2.8.6'
+    api 'androidx.lifecycle:lifecycle-livedata:2.8.7'
 }
 
 // === Maven Central configuration ===

--- a/ble/build.gradle
+++ b/ble/build.gradle
@@ -32,7 +32,7 @@ android {
 }
 
 dependencies {
-    api 'androidx.annotation:annotation:1.8.2'
+    api 'androidx.annotation:annotation:1.9.1'
     //noinspection GradleDependency
     implementation 'androidx.core:core:1.12.0' // Don't upgrade to 1.13.0, as it increases the minSdk to 19.
 

--- a/ble/build.gradle
+++ b/ble/build.gradle
@@ -4,11 +4,11 @@ plugins {
 
 android {
     namespace 'no.nordicsemi.android.ble'
-    compileSdk 34
+    compileSdk 35
 
     defaultConfig {
         minSdk 18
-        targetSdk 34
+        targetSdk 35
     }
 
     buildTypes {

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ buildscript {
         maven { url "https://plugins.gradle.org/m2/" }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.8.0'
+        classpath 'com.android.tools.build:gradle:8.8.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "org.jetbrains.kotlin:compose-compiler-gradle-plugin:$kotlin_version"
         classpath "com.google.dagger:hilt-android-gradle-plugin:2.52"

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     // https://kotlinlang.org/docs/releases.html#release-details
-    ext.kotlin_version = '2.0.21'
+    ext.kotlin_version = '2.1.10'
     // https://plugins.gradle.org/plugin/io.github.gradle-nexus.publish-plugin
     ext.gradle_nexus_publish_plugin = '2.0.0'
 

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ buildscript {
         classpath 'com.android.tools.build:gradle:8.8.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "org.jetbrains.kotlin:compose-compiler-gradle-plugin:$kotlin_version"
-        classpath "com.google.dagger:hilt-android-gradle-plugin:2.52"
+        classpath "com.google.dagger:hilt-android-gradle-plugin:2.54"
         classpath "io.github.gradle-nexus:publish-plugin:$gradle_nexus_publish_plugin"
         classpath "com.squareup.wire:wire-gradle-plugin:5.1.0"
     }

--- a/examples/ble-gatt-client/build.gradle
+++ b/examples/ble-gatt-client/build.gradle
@@ -39,9 +39,9 @@ android {
 }
 
 dependencies {
-    implementation 'androidx.core:core-ktx:1.13.1'
+    implementation 'androidx.core:core-ktx:1.15.0'
     implementation 'androidx.appcompat:appcompat:1.7.0'
-    implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
+    implementation 'androidx.constraintlayout:constraintlayout:2.2.1'
 
     implementation project(':ble-ktx')
 

--- a/examples/ble-gatt-client/build.gradle
+++ b/examples/ble-gatt-client/build.gradle
@@ -5,12 +5,12 @@ plugins {
 
 android {
     namespace 'no.nordicsemi.android.ble.ble_gatt_client'
-    compileSdk 34
+    compileSdk 35
 
     defaultConfig {
         applicationId "no.nordicsemi.android.ble.ble_gatt_client"
         minSdk 27
-        targetSdk 34
+        targetSdk 35
         versionCode 1
         versionName "1.0"
 

--- a/examples/ble-gatt-server/build.gradle
+++ b/examples/ble-gatt-server/build.gradle
@@ -39,9 +39,9 @@ android {
 }
 
 dependencies {
-    implementation 'androidx.core:core-ktx:1.13.1'
+    implementation 'androidx.core:core-ktx:1.15.0'
     implementation 'androidx.appcompat:appcompat:1.7.0'
-    implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
+    implementation 'androidx.constraintlayout:constraintlayout:2.2.1'
 
     implementation project(':ble-ktx')
 

--- a/examples/ble-gatt-server/build.gradle
+++ b/examples/ble-gatt-server/build.gradle
@@ -5,12 +5,12 @@ plugins {
 
 android {
     namespace 'no.nordicsemi.android.ble.ble_gatt_server'
-    compileSdk 34
+    compileSdk 35
 
     defaultConfig {
         applicationId "no.nordicsemi.android.ble.ble_gatt_server"
         minSdk 27
-        targetSdk 34
+        targetSdk 35
         versionCode 1
         versionName "1.0"
 

--- a/examples/trivia/build.gradle
+++ b/examples/trivia/build.gradle
@@ -10,12 +10,12 @@ plugins {
 
 android {
     namespace 'no.nordicsemi.android.ble.trivia'
-    compileSdk 34
+    compileSdk 35
 
     defaultConfig {
         applicationId "no.nordicsemi.android.ble.trivia"
         minSdk 21
-        targetSdk 34
+        targetSdk 35
         versionCode 1
         versionName "1.0"
     }

--- a/examples/trivia/build.gradle
+++ b/examples/trivia/build.gradle
@@ -53,23 +53,23 @@ dependencies {
     implementation project(path: ':ble-ktx')
 
     // Dagger and Hilt
-    implementation 'com.google.dagger:hilt-android:2.52'
-    kapt 'com.google.dagger:hilt-compiler:2.52'
+    implementation 'com.google.dagger:hilt-android:2.54'
+    kapt 'com.google.dagger:hilt-compiler:2.54'
     implementation 'androidx.hilt:hilt-navigation-compose:1.2.0'
     kapt 'androidx.hilt:hilt-compiler:1.2.0'
 
     // Nordic theme
-    implementation 'no.nordicsemi.android.common:ui:2.1.0'
-    implementation 'no.nordicsemi.android.common:theme:2.1.0'
-    implementation 'no.nordicsemi.android.common:permissions-ble:2.1.0'
-    implementation 'no.nordicsemi.android.common:navigation:2.1.0'
+    implementation 'no.nordicsemi.android.common:ui:2.4.0'
+    implementation 'no.nordicsemi.android.common:theme:2.4.0'
+    implementation 'no.nordicsemi.android.common:permissions-ble:2.4.0'
+    implementation 'no.nordicsemi.android.common:navigation:2.4.0'
 
     // Jetpack Compose bom
-    implementation platform('androidx.compose:compose-bom:2024.09.03')
+    implementation platform('androidx.compose:compose-bom:2025.02.00')
 
     // Text, color, Surface
     implementation "androidx.compose.material3:material3"
-    implementation 'androidx.activity:activity-compose:1.9.2'
+    implementation 'androidx.activity:activity-compose:1.10.1'
     implementation "androidx.compose.runtime:runtime-livedata"
 
     // To show Preview

--- a/test/build.gradle
+++ b/test/build.gradle
@@ -49,28 +49,28 @@ android {
 dependencies {
     implementation project(path: ':ble-ktx')
     // Nordic theme
-    implementation "no.nordicsemi.android.common:ui:2.1.0"
-    implementation "no.nordicsemi.android.common:theme:2.1.0"
-    implementation 'no.nordicsemi.android.common:permissions-ble:2.1.0'
-    implementation 'no.nordicsemi.android.common:navigation:2.1.0'
+    implementation "no.nordicsemi.android.common:ui:2.4.0"
+    implementation "no.nordicsemi.android.common:theme:2.4.0"
+    implementation 'no.nordicsemi.android.common:permissions-ble:2.4.0'
+    implementation 'no.nordicsemi.android.common:navigation:2.4.0'
 
     implementation 'com.github.jeziellago:compose-markdown:0.4.1'
 
     // Jetpack Compose bom
-    implementation platform('androidx.compose:compose-bom:2024.09.03')
+    implementation platform('androidx.compose:compose-bom:2025.02.00')
 
     // Text, Color, Surface
     implementation 'androidx.compose.material3:material3'
-    implementation 'androidx.activity:activity-compose:1.9.2'
-    implementation 'androidx.lifecycle:lifecycle-runtime-compose:2.8.6'
+    implementation 'androidx.activity:activity-compose:1.10.1'
+    implementation 'androidx.lifecycle:lifecycle-runtime-compose:2.8.7'
 
     // Preview
     debugImplementation "androidx.compose.ui:ui-tooling"
     implementation "androidx.compose.ui:ui-tooling-preview"
 
     // Dagger and Hilt
-    implementation 'com.google.dagger:hilt-android:2.52'
-    kapt 'com.google.dagger:hilt-compiler:2.52'
+    implementation 'com.google.dagger:hilt-android:2.54'
+    kapt 'com.google.dagger:hilt-compiler:2.54'
     implementation 'androidx.hilt:hilt-navigation-compose:1.2.0'
     kapt 'androidx.hilt:hilt-compiler:1.2.0'
 

--- a/test/build.gradle
+++ b/test/build.gradle
@@ -8,12 +8,12 @@ plugins {
 
 android {
     namespace 'no.nordicsemi.andorid.ble.test'
-    compileSdk 34
+    compileSdk 35
 
     defaultConfig {
         applicationId "no.nordicsemi.andorid.ble.test"
         minSdk 21
-        targetSdk 34
+        targetSdk 35
         versionCode 1
         versionName "1.0"
 


### PR DESCRIPTION
This PR updates the following:
- Kotlin 2.0.21 -> 2.1.10
- Gradle build tools 8.8.0 -> 8.8.2 (Android Studio Ladybug Featru Drop 2024.2.2 Patch 2)
- Other dependencies from Maven
- Android target API set to 35 (Android 15)