### PR TITLE
Fixes issue where gatt is not closed before the next 'connectGatt' is…

### DIFF
--- a/ble/src/main/java/no/nordicsemi/android/ble/BleManagerHandler.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/BleManagerHandler.java
@@ -697,6 +697,9 @@ abstract class BleManagerHandler extends RequestHandler {
 							preferredPhy = connectRequest.getPreferredPhy();
 						}
 						final int finalPreferredPhy = preferredPhy;
+						var gatt = bluetoothGatt;
+						log(Log.DEBUG, () -> "gatt.close()");
+						gatt.close();
 						log(Log.DEBUG, () ->
 								"gatt = device.connectGatt(autoConnect = true, TRANSPORT_LE, "
 										+ ParserUtils.phyMaskToString(finalPreferredPhy) + ")");


### PR DESCRIPTION
In some cases, there were race condition where the previous gatt was not closed, but `bluetoothGatt` gets overridden due to the next `connectGatt` call being executed. With this previous gatt client not closed - it remains in memory keep consuming assigned seat for ble gatt on operating system.

This pull request ensures to close the gatt object before the next `connectGatt` is executed.