### PR TITLE
Fix the issue where gatt.disconnect() may throw a SecurityException

### DIFF
--- a/ble/src/main/java/no/nordicsemi/android/ble/BleManagerHandler.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/BleManagerHandler.java
@@ -810,7 +810,11 @@ abstract class BleManagerHandler extends RequestHandler {
 				postConnectionStateChange(o -> o.onDeviceDisconnecting(device));
 			}
 			log(Log.DEBUG, () -> "gatt.disconnect()");
-			gatt.disconnect();
+			try {
+				gatt.disconnect();
+			} catch (final SecurityException e) {
+				log(Log.ERROR, e::getLocalizedMessage);
+			}
 			if (wasConnected)
 				return;
 


### PR DESCRIPTION
Fix the following Firebase crash:
```
Fatal Exception: java.lang.SecurityException: Need BLUETOOTH_PRIVILEGED permission: Neither user 10049 nor current process has android.permission.BLUETOOTH_PRIVILEGED.
       at android.os.Parcel.createExceptionOrNull(Parcel.java:2439)
       at android.os.Parcel.createException(Parcel.java:2423)
       at android.os.Parcel.readException(Parcel.java:2406)
       at android.os.Parcel.readException(Parcel.java:2348)
       at android.bluetooth.IBluetoothGatt$Stub$Proxy.clientDisconnect(IBluetoothGatt.java:2526)
       at android.bluetooth.BluetoothGatt.disconnect(BluetoothGatt.java:1005)
       at no.nordicsemi.android.ble.BleManagerHandler.internalDisconnect(BleManagerHandler.java:813)
       at no.nordicsemi.android.ble.BleManagerHandler.onRequestTimeout(BleManagerHandler.java:1717)
       at no.nordicsemi.android.ble.TimeoutableRequest.lambda$notifyStarted$0(TimeoutableRequest.java:230)
       at no.nordicsemi.android.ble.BleManagerHandler$3.run(BleManagerHandler.java:1738)
       at java.util.TimerThread.mainLoop(Timer.java:562)
       at java.util.TimerThread.run(Timer.java:512)
```