### PR TITLE
Migration following OSSRH Staging API

### DIFF
--- a/gradle/publish-root.gradle
+++ b/gradle/publish-root.gradle
@@ -13,6 +13,7 @@ nexusPublishing {
 
     repositories {
         sonatype {
+            nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
             stagingProfileId = System.env.SONATYPE_STAGING_PROFILE_ID
             username = System.env.OSSR_USERNAME
             password = System.env.OSSR_PASSWORD


### PR DESCRIPTION
We're following the migration guide from here:
https://central.sonatype.org/publish/publish-portal-ossrh-staging-api/
and
https://github.com/gradle-nexus/publish-plugin/?tab=readme-ov-file#publishing-to-maven-central-via-sonatype-central