### PR TITLE
Adding missing `timeout` methods

### DIFF
--- a/ble/src/main/java/no/nordicsemi/android/ble/ConditionalWaitRequest.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/ConditionalWaitRequest.java
@@ -3,8 +3,10 @@ package no.nordicsemi.android.ble;
 import android.os.Handler;
 import android.util.Log;
 
+import androidx.annotation.IntRange;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+
 import no.nordicsemi.android.ble.callback.AfterCallback;
 import no.nordicsemi.android.ble.callback.BeforeCallback;
 import no.nordicsemi.android.ble.callback.FailCallback;
@@ -46,6 +48,13 @@ public final class ConditionalWaitRequest<T> extends AwaitingRequest<T> implemen
 	@Override
 	public ConditionalWaitRequest<T> setHandler(@Nullable final Handler handler) {
 		super.setHandler(handler);
+		return this;
+	}
+
+	@NonNull
+	@Override
+	public ConditionalWaitRequest<T> timeout(@IntRange(from = 0) final long timeout) {
+		super.timeout(timeout);
 		return this;
 	}
 

--- a/ble/src/main/java/no/nordicsemi/android/ble/ReadRequest.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/ReadRequest.java
@@ -29,8 +29,10 @@ import android.bluetooth.BluetoothGattDescriptor;
 import android.os.Handler;
 import android.util.Log;
 
+import androidx.annotation.IntRange;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+
 import no.nordicsemi.android.ble.callback.AfterCallback;
 import no.nordicsemi.android.ble.callback.BeforeCallback;
 import no.nordicsemi.android.ble.callback.DataReceivedCallback;
@@ -83,6 +85,13 @@ public final class ReadRequest extends TimeoutableValueRequest<DataReceivedCallb
 	@Override
 	public ReadRequest setHandler(@Nullable final Handler handler) {
 		super.setHandler(handler);
+		return this;
+	}
+
+	@NonNull
+	@Override
+	public ReadRequest timeout(@IntRange(from = 0) final long timeout) {
+		super.timeout(timeout);
 		return this;
 	}
 

--- a/ble/src/main/java/no/nordicsemi/android/ble/WaitForReadRequest.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/WaitForReadRequest.java
@@ -9,6 +9,7 @@ import android.util.Log;
 import androidx.annotation.IntRange;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+
 import no.nordicsemi.android.ble.callback.AfterCallback;
 import no.nordicsemi.android.ble.callback.BeforeCallback;
 import no.nordicsemi.android.ble.callback.DataSentCallback;
@@ -77,6 +78,13 @@ public final class WaitForReadRequest extends AwaitingRequest<DataSentCallback> 
 	@Override
 	public WaitForReadRequest setHandler(@Nullable final Handler handler) {
 		super.setHandler(handler);
+		return this;
+	}
+
+	@NonNull
+	@Override
+	public WaitForReadRequest timeout(@IntRange(from = 0) final long timeout) {
+		super.timeout(timeout);
 		return this;
 	}
 

--- a/ble/src/main/java/no/nordicsemi/android/ble/WriteRequest.java
+++ b/ble/src/main/java/no/nordicsemi/android/ble/WriteRequest.java
@@ -29,11 +29,12 @@ import android.bluetooth.BluetoothGattDescriptor;
 import android.os.Handler;
 import android.util.Log;
 
-import java.util.Arrays;
-
 import androidx.annotation.IntRange;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+
+import java.util.Arrays;
+
 import no.nordicsemi.android.ble.annotation.WriteType;
 import no.nordicsemi.android.ble.callback.AfterCallback;
 import no.nordicsemi.android.ble.callback.BeforeCallback;
@@ -108,6 +109,13 @@ public final class WriteRequest extends TimeoutableValueRequest<DataSentCallback
 	@Override
 	public WriteRequest setHandler(@Nullable final Handler handler) {
 		super.setHandler(handler);
+		return this;
+	}
+
+	@NonNull
+	@Override
+	public WriteRequest timeout(@IntRange(from = 0) final long timeout) {
+		super.timeout(timeout);
 		return this;
 	}
 


### PR DESCRIPTION
The `timeout` methods were available from a super type, but the returned type didn't match the request type.

This PR fixes that by adding `timeout(..)` methods.